### PR TITLE
Add Rhai DSL query and analysis run foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "const-random",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,6 +50,26 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "tiny-keccak",
+]
 
 [[package]]
 name = "crc32fast"
@@ -36,6 +87,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,10 +103,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "memchr"
@@ -65,6 +174,7 @@ dependencies = [
  "mercurio-language-contracts",
  "mercurio-model",
  "mercurio-runtime",
+ "rhai",
  "serde",
  "serde_json",
  "zip",
@@ -135,6 +245,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+dependencies = [
+ "spin",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,6 +300,41 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rhai"
+version = "1.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd4dd0f8c36625202a4ba553c416c19b719947cd2a31d1bda06126e4a5727daf"
+dependencies = [
+ "ahash",
+ "bitflags",
+ "no-std-compat",
+ "num-traits",
+ "once_cell",
+ "rhai_codegen",
+ "smallvec",
+ "smartstring",
+ "thin-vec",
+ "web-time",
+]
+
+[[package]]
+name = "rhai_codegen"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cd3a7535e50bf36857e7be7bec276d334e8c2dfa469c2201226fd01638ea5ca"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "serde"
@@ -202,6 +386,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "smartstring"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
+dependencies = [
+ "autocfg",
+ "static_assertions",
+ "version_check",
+]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,10 +432,112 @@ dependencies = [
 ]
 
 [[package]]
+name = "thin-vec"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f7e269b48f0a7dd0146680fa24b50cc67fc0373f086a5b2f99bd084639b482"
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zip"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,6 @@ reqwest = { version = "0.13", features = ["blocking", "json"] }
 base64 = "0.22"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
+rhai = { version = "1", default-features = false, features = ["std", "sync"] }
 time = { version = "0.3", features = ["formatting"] }
 zip = { version = "0.6", default-features = false, features = ["deflate"] }

--- a/crates/mercurio-foundation/Cargo.toml
+++ b/crates/mercurio-foundation/Cargo.toml
@@ -16,4 +16,5 @@ mercurio-model = { path = "../mercurio-model", version = "0.1.0" }
 mercurio-runtime = { path = "../mercurio-runtime", version = "0.1.0" }
 serde.workspace = true
 serde_json.workspace = true
+rhai.workspace = true
 zip.workspace = true

--- a/crates/mercurio-foundation/src/dsl/mod.rs
+++ b/crates/mercurio-foundation/src/dsl/mod.rs
@@ -281,6 +281,10 @@ mod tests {
                         ("declared_name".into(), serde_json::json!("Vehicle")),
                         ("mass_kg".into(), serde_json::json!(10.0)),
                         (
+                            "features".into(),
+                            serde_json::json!(["feature.Demo.Vehicle.payloadMass"]),
+                        ),
+                        (
                             "members".into(),
                             serde_json::json!(["type.Demo.Vehicle.wheel"]),
                         ),
@@ -294,6 +298,19 @@ mod tests {
                         ("declared_name".into(), serde_json::json!("wheel")),
                         ("mass_kg".into(), serde_json::json!(2.5)),
                         ("owner".into(), serde_json::json!("type.Demo.Vehicle")),
+                    ]),
+                },
+                KirElement {
+                    id: "feature.Demo.Vehicle.payloadMass".into(),
+                    kind: "AttributeUsage".into(),
+                    layer: 3,
+                    properties: BTreeMap::from([
+                        ("declared_name".into(), serde_json::json!("payload_mass_kg")),
+                        ("owner".into(), serde_json::json!("type.Demo.Vehicle")),
+                        (
+                            "expression_ir".into(),
+                            serde_json::json!({"kind": "literal", "value": 3.0}),
+                        ),
                     ]),
                 },
                 KirElement {
@@ -380,6 +397,19 @@ mod tests {
             .unwrap();
         assert_eq!(result.columns, vec!["value"]);
         assert_eq!(result.rows[0][0], serde_json::json!(16.5));
+    }
+
+    #[test]
+    fn property_resolves_owned_literal_feature() {
+        let engine = RhaiEngine::new();
+        let result = engine
+            .eval_query(
+                sample_graph(),
+                r#"model.element("type.Demo.Vehicle").property("payload_mass_kg")"#,
+            )
+            .unwrap();
+        assert_eq!(result.columns, vec!["value"]);
+        assert_eq!(result.rows[0][0], serde_json::json!(3.0));
     }
 
     #[test]

--- a/crates/mercurio-foundation/src/dsl/mod.rs
+++ b/crates/mercurio-foundation/src/dsl/mod.rs
@@ -111,6 +111,7 @@ impl RhaiEngine {
                 "count_by_kind".into(),
                 "reachable".into(),
                 "specialization_depth".into(),
+                "sum".into(),
             ],
         }
     }
@@ -278,6 +279,7 @@ mod tests {
                     layer: 2,
                     properties: BTreeMap::from([
                         ("declared_name".into(), serde_json::json!("Vehicle")),
+                        ("mass_kg".into(), serde_json::json!(10.0)),
                         (
                             "members".into(),
                             serde_json::json!(["type.Demo.Vehicle.wheel"]),
@@ -290,6 +292,7 @@ mod tests {
                     layer: 2,
                     properties: BTreeMap::from([
                         ("declared_name".into(), serde_json::json!("wheel")),
+                        ("mass_kg".into(), serde_json::json!(2.5)),
                         ("owner".into(), serde_json::json!("type.Demo.Vehicle")),
                     ]),
                 },
@@ -297,10 +300,10 @@ mod tests {
                     id: "type.Demo.Animal".into(),
                     kind: "PartDefinition".into(),
                     layer: 2,
-                    properties: BTreeMap::from([(
-                        "declared_name".into(),
-                        serde_json::json!("Animal"),
-                    )]),
+                    properties: BTreeMap::from([
+                        ("declared_name".into(), serde_json::json!("Animal")),
+                        ("mass_kg".into(), serde_json::json!(4.0)),
+                    ]),
                 },
             ],
         };
@@ -364,6 +367,19 @@ mod tests {
             .unwrap();
         assert_eq!(result.columns, vec!["PartDefinition", "PartUsage"]);
         assert_eq!(result.rows.len(), 1);
+    }
+
+    #[test]
+    fn stdlib_sum_numeric_properties() {
+        let engine = RhaiEngine::new();
+        let result = engine
+            .eval_query(
+                sample_graph(),
+                r#"sum(model.parts().map(|p| p.property("mass_kg")))"#,
+            )
+            .unwrap();
+        assert_eq!(result.columns, vec!["value"]);
+        assert_eq!(result.rows[0][0], serde_json::json!(16.5));
     }
 
     #[test]

--- a/crates/mercurio-foundation/src/dsl/mod.rs
+++ b/crates/mercurio-foundation/src/dsl/mod.rs
@@ -111,6 +111,8 @@ impl RhaiEngine {
                 "count_by_kind".into(),
                 "reachable".into(),
                 "specialization_depth".into(),
+                "max".into(),
+                "min".into(),
                 "sum".into(),
             ],
         }
@@ -397,6 +399,45 @@ mod tests {
             .unwrap();
         assert_eq!(result.columns, vec!["value"]);
         assert_eq!(result.rows[0][0], serde_json::json!(16.5));
+    }
+
+    #[test]
+    fn stdlib_max_and_min_numeric_properties() {
+        let engine = RhaiEngine::new();
+        let max_result = engine
+            .eval_query(
+                sample_graph(),
+                r#"max(model.parts().map(|p| p.property("mass_kg")))"#,
+            )
+            .unwrap();
+        let min_result = engine
+            .eval_query(
+                sample_graph(),
+                r#"min(model.parts().map(|p| p.property("mass_kg")))"#,
+            )
+            .unwrap();
+
+        assert_eq!(max_result.columns, vec!["value"]);
+        assert_eq!(max_result.rows[0][0], serde_json::json!(10.0));
+        assert_eq!(min_result.columns, vec!["value"]);
+        assert_eq!(min_result.rows[0][0], serde_json::json!(2.5));
+    }
+
+    #[test]
+    fn stdlib_max_and_min_binary_values() {
+        let engine = RhaiEngine::new();
+        let result = engine
+            .eval_query(
+                sample_graph(),
+                r#"#{larger: max(12.0, 7.0), smaller: min(12.0, 7.0)}"#,
+            )
+            .unwrap();
+
+        assert_eq!(result.columns, vec!["larger", "smaller"]);
+        assert_eq!(
+            result.rows[0],
+            vec![serde_json::json!(12.0), serde_json::json!(7.0)]
+        );
     }
 
     #[test]

--- a/crates/mercurio-foundation/src/dsl/mod.rs
+++ b/crates/mercurio-foundation/src/dsl/mod.rs
@@ -1,0 +1,375 @@
+mod stdlib;
+mod types;
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use rhai::{Engine, EvalAltResult, Scope};
+use serde::{Deserialize, Serialize};
+use serde_json::{Number, Value};
+
+use crate::graph::Graph;
+use crate::ir::{KirFieldKind, KirFieldRegistry};
+use types::ModelContext;
+
+pub use types::{DslEdge, DslElement, ElementSet};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DslQueryResult {
+    pub columns: Vec<String>,
+    pub rows: Vec<Vec<Value>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DslError(String);
+
+impl std::fmt::Display for DslError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for DslError {}
+
+impl From<Box<EvalAltResult>> for DslError {
+    fn from(error: Box<EvalAltResult>) -> Self {
+        Self(error.to_string())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DslFieldSchema {
+    pub name: String,
+    pub kind: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DslSchema {
+    pub element_kinds: Vec<String>,
+    pub fields: Vec<DslFieldSchema>,
+    pub stdlib_functions: Vec<String>,
+}
+
+pub struct RhaiEngine {
+    engine: Engine,
+}
+
+impl RhaiEngine {
+    pub fn new() -> Self {
+        let mut engine = Engine::new();
+
+        engine.set_max_operations(500_000);
+        engine.set_max_string_size(1_000_000);
+        engine.set_max_array_size(50_000);
+        engine.set_max_map_size(50_000);
+        engine.set_max_call_levels(32);
+        engine.disable_symbol("print");
+        engine.disable_symbol("debug");
+
+        types::register_types(&mut engine);
+        stdlib::register_stdlib(&mut engine);
+
+        Self { engine }
+    }
+
+    pub fn eval_query(&self, graph: Arc<Graph>, script: &str) -> Result<DslQueryResult, DslError> {
+        let mut scope = Scope::new();
+        scope.push("model", ModelContext::new(graph));
+
+        let result: rhai::Dynamic = self.engine.eval_with_scope(&mut scope, script)?;
+        Ok(dynamic_to_query_result(result))
+    }
+
+    pub fn schema(graph: &Graph) -> DslSchema {
+        let mut kinds = BTreeSet::new();
+        let mut field_names = BTreeSet::from([
+            "element_id".to_string(),
+            "id".to_string(),
+            "kind".to_string(),
+            "layer".to_string(),
+        ]);
+
+        for element in graph.elements() {
+            kinds.insert(element.kind.as_ref().to_string());
+            field_names.extend(element.properties.to_btree_map().into_keys());
+        }
+
+        let registry = KirFieldRegistry::standard();
+        let fields = field_names
+            .into_iter()
+            .map(|name| DslFieldSchema {
+                kind: field_kind_label(&registry, &name).to_string(),
+                name,
+            })
+            .collect();
+
+        DslSchema {
+            element_kinds: kinds.into_iter().collect(),
+            fields,
+            stdlib_functions: vec![
+                "all_parts".into(),
+                "count_by_kind".into(),
+                "reachable".into(),
+                "specialization_depth".into(),
+            ],
+        }
+    }
+}
+
+impl Default for RhaiEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn dynamic_to_query_result(result: rhai::Dynamic) -> DslQueryResult {
+    if let Some(query_result) = result.clone().try_cast::<DslQueryResult>() {
+        return query_result;
+    }
+    if let Some(set) = result.clone().try_cast::<ElementSet>() {
+        return set.to_query_result();
+    }
+    if let Some(value) = result.clone().try_cast::<i64>() {
+        return single_value_result(Value::from(value));
+    }
+    if let Some(value) = result.clone().try_cast::<f64>() {
+        return single_value_result(float_to_json(value));
+    }
+    if let Some(value) = result.clone().try_cast::<bool>() {
+        return single_value_result(Value::Bool(value));
+    }
+    if let Some(value) = result.clone().try_cast::<String>() {
+        return single_value_result(Value::String(value));
+    }
+    if let Some(map) = result.clone().try_cast::<rhai::Map>() {
+        return map_to_query_result(map);
+    }
+    if let Some(array) = result.clone().try_cast::<rhai::Array>() {
+        return array_to_query_result(array);
+    }
+    single_value_result(rhai_dynamic_to_json(result))
+}
+
+fn single_value_result(value: Value) -> DslQueryResult {
+    DslQueryResult {
+        columns: vec!["value".into()],
+        rows: vec![vec![value]],
+    }
+}
+
+fn field_kind_label(registry: &KirFieldRegistry, name: &str) -> &'static str {
+    match registry.field(name).map(|spec| spec.kind) {
+        Some(KirFieldKind::Reference) => "reference",
+        Some(KirFieldKind::ReferenceList) => "list",
+        _ => "scalar",
+    }
+}
+
+fn map_to_query_result(map: rhai::Map) -> DslQueryResult {
+    let columns = map.keys().map(ToString::to_string).collect::<Vec<_>>();
+    let row = columns
+        .iter()
+        .map(|column| {
+            map.get(column.as_str())
+                .cloned()
+                .map(rhai_dynamic_to_json)
+                .unwrap_or(Value::Null)
+        })
+        .collect();
+    DslQueryResult {
+        columns,
+        rows: vec![row],
+    }
+}
+
+fn array_to_query_result(array: rhai::Array) -> DslQueryResult {
+    if let Some(first) = array.first() {
+        if first.is::<rhai::Map>() {
+            let first_map = first.clone().cast::<rhai::Map>();
+            let columns = first_map
+                .keys()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>();
+            let rows = array
+                .into_iter()
+                .filter_map(|value| value.try_cast::<rhai::Map>())
+                .map(|map| {
+                    columns
+                        .iter()
+                        .map(|column| {
+                            map.get(column.as_str())
+                                .cloned()
+                                .map(rhai_dynamic_to_json)
+                                .unwrap_or(Value::Null)
+                        })
+                        .collect()
+                })
+                .collect();
+            return DslQueryResult { columns, rows };
+        }
+    }
+
+    DslQueryResult {
+        columns: vec!["value".into()],
+        rows: array
+            .into_iter()
+            .map(|value| vec![rhai_dynamic_to_json(value)])
+            .collect(),
+    }
+}
+
+fn rhai_dynamic_to_json(value: rhai::Dynamic) -> Value {
+    if value.is::<i64>() {
+        return Value::from(value.cast::<i64>());
+    }
+    if value.is::<f64>() {
+        return float_to_json(value.cast::<f64>());
+    }
+    if value.is::<bool>() {
+        return Value::Bool(value.cast::<bool>());
+    }
+    if value.is::<String>() {
+        return Value::String(value.cast::<String>());
+    }
+    if value.is::<rhai::Array>() {
+        return Value::Array(
+            value
+                .cast::<rhai::Array>()
+                .into_iter()
+                .map(rhai_dynamic_to_json)
+                .collect(),
+        );
+    }
+    if value.is::<rhai::Map>() {
+        let object = value
+            .cast::<rhai::Map>()
+            .into_iter()
+            .map(|(key, value)| (key.to_string(), rhai_dynamic_to_json(value)))
+            .collect();
+        return Value::Object(object);
+    }
+    if value.is_unit() {
+        return Value::Null;
+    }
+    Value::String(format!("{value:?}"))
+}
+
+fn float_to_json(value: f64) -> Value {
+    Number::from_f64(value)
+        .map(Value::Number)
+        .unwrap_or(Value::Null)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use mercurio_kir::{KirDocument, KirElement};
+
+    use super::*;
+
+    fn sample_graph() -> Arc<Graph> {
+        let document = KirDocument {
+            metadata: BTreeMap::new(),
+            elements: vec![
+                KirElement {
+                    id: "type.Demo.Vehicle".into(),
+                    kind: "PartDefinition".into(),
+                    layer: 2,
+                    properties: BTreeMap::from([
+                        ("declared_name".into(), serde_json::json!("Vehicle")),
+                        (
+                            "members".into(),
+                            serde_json::json!(["type.Demo.Vehicle.wheel"]),
+                        ),
+                    ]),
+                },
+                KirElement {
+                    id: "type.Demo.Vehicle.wheel".into(),
+                    kind: "PartUsage".into(),
+                    layer: 2,
+                    properties: BTreeMap::from([
+                        ("declared_name".into(), serde_json::json!("wheel")),
+                        ("owner".into(), serde_json::json!("type.Demo.Vehicle")),
+                    ]),
+                },
+                KirElement {
+                    id: "type.Demo.Animal".into(),
+                    kind: "PartDefinition".into(),
+                    layer: 2,
+                    properties: BTreeMap::from([(
+                        "declared_name".into(),
+                        serde_json::json!("Animal"),
+                    )]),
+                },
+            ],
+        };
+        Arc::new(Graph::from_document(document).unwrap())
+    }
+
+    #[test]
+    fn count_all_parts() {
+        let engine = RhaiEngine::new();
+        let result = engine
+            .eval_query(sample_graph(), "model.parts().count()")
+            .unwrap();
+        assert_eq!(result.rows.len(), 1);
+        assert_eq!(result.rows[0][0], serde_json::json!(3));
+    }
+
+    #[test]
+    fn filter_by_kind() {
+        let engine = RhaiEngine::new();
+        let result = engine
+            .eval_query(
+                sample_graph(),
+                r#"model.parts().where(|p| p.kind == "PartDefinition").count()"#,
+            )
+            .unwrap();
+        assert_eq!(result.rows[0][0], serde_json::json!(2));
+    }
+
+    #[test]
+    fn select_names() {
+        let engine = RhaiEngine::new();
+        let result = engine
+            .eval_query(
+                sample_graph(),
+                r#"model.parts()
+                       .where(|p| p.kind == "PartDefinition")
+                       .select(["declared_name"])"#,
+            )
+            .unwrap();
+        assert_eq!(result.columns, vec!["declared_name"]);
+        assert_eq!(result.rows.len(), 2);
+    }
+
+    #[test]
+    fn traverse_outgoing() {
+        let engine = RhaiEngine::new();
+        let result = engine
+            .eval_query(
+                sample_graph(),
+                r#"model.element("type.Demo.Vehicle").outgoing("members").count()"#,
+            )
+            .unwrap();
+        assert_eq!(result.rows[0][0], serde_json::json!(1));
+    }
+
+    #[test]
+    fn stdlib_count_by_kind() {
+        let engine = RhaiEngine::new();
+        let result = engine
+            .eval_query(sample_graph(), "count_by_kind(model.parts())")
+            .unwrap();
+        assert_eq!(result.columns, vec!["PartDefinition", "PartUsage"]);
+        assert_eq!(result.rows.len(), 1);
+    }
+
+    #[test]
+    fn unknown_element_returns_unit() {
+        let engine = RhaiEngine::new();
+        let result = engine.eval_query(sample_graph(), r#"model.element("nonexistent")"#);
+        assert!(result.is_ok());
+    }
+}

--- a/crates/mercurio-foundation/src/dsl/mod.rs
+++ b/crates/mercurio-foundation/src/dsl/mod.rs
@@ -1,14 +1,21 @@
 mod stdlib;
 mod types;
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 use rhai::{Engine, EvalAltResult, Scope};
 use serde::{Deserialize, Serialize};
-use serde_json::{Number, Value};
+use serde_json::{Number, Value, json};
 
+use crate::capability::{
+    CapabilityRunReport, CapabilityRunStatus, CapabilityTarget, EvidenceEdge, EvidenceGraph,
+    EvidenceNode, EvidenceNodeKind, EvidenceRelation, InsightConfidence, InsightKind,
+    InsightPolarity, InsightScope, InsightSeverity, SemanticArtifact, SemanticElementRef,
+    SemanticInsight,
+};
 use crate::graph::Graph;
+use crate::identity::stable_digest;
 use crate::ir::{KirFieldKind, KirFieldRegistry};
 use types::ModelContext;
 
@@ -50,6 +57,15 @@ pub struct DslSchema {
     pub stdlib_functions: Vec<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DslAnalysisRunSpec {
+    pub run_id: String,
+    pub capability_id: String,
+    pub script: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject_element_id: Option<String>,
+}
+
 pub struct RhaiEngine {
     engine: Engine,
 }
@@ -78,6 +94,15 @@ impl RhaiEngine {
 
         let result: rhai::Dynamic = self.engine.eval_with_scope(&mut scope, script)?;
         Ok(dynamic_to_query_result(result))
+    }
+
+    pub fn eval_analysis_run(
+        &self,
+        graph: Arc<Graph>,
+        spec: DslAnalysisRunSpec,
+    ) -> Result<CapabilityRunReport, DslError> {
+        let result = self.eval_query(Arc::clone(&graph), &spec.script)?;
+        Ok(query_result_to_analysis_report(&graph, spec, result))
     }
 
     pub fn schema(graph: &Graph) -> DslSchema {
@@ -117,6 +142,198 @@ impl RhaiEngine {
             ],
         }
     }
+}
+
+fn query_result_to_analysis_report(
+    graph: &Graph,
+    spec: DslAnalysisRunSpec,
+    result: DslQueryResult,
+) -> CapabilityRunReport {
+    let status = status_from_result(&result);
+    let subject = spec
+        .subject_element_id
+        .as_deref()
+        .map(|element_id| semantic_element_ref(graph, element_id));
+    let target = subject
+        .as_ref()
+        .map(|element| CapabilityTarget::Element {
+            element_id: element.element_id.clone(),
+        })
+        .unwrap_or(CapabilityTarget::Workspace);
+    let evidence_id = format!("evidence.{}.analysis_run", spec.run_id);
+    let artifact_id = format!("artifact.{}.dsl_result", spec.run_id);
+    let payload = json!({
+        "columns": result.columns,
+        "rows": result.rows,
+        "script": spec.script,
+    });
+    let artifact = SemanticArtifact {
+        id: artifact_id.clone(),
+        kind: "dsl_analysis_result".to_string(),
+        schema: "mercurio.dsl.analysis_result.v1".to_string(),
+        digest: value_digest(&payload),
+        element_refs: subject.clone().into_iter().collect(),
+        payload,
+    };
+    let insight = insight_from_result(
+        &spec.run_id,
+        subject.clone(),
+        status,
+        &evidence_id,
+        &artifact,
+    );
+
+    CapabilityRunReport {
+        run_id: spec.run_id,
+        capability_id: spec.capability_id,
+        status,
+        target,
+        insights: insight.into_iter().collect(),
+        artifacts: vec![artifact],
+        evidence: EvidenceGraph {
+            nodes: vec![
+                EvidenceNode {
+                    id: evidence_id.clone(),
+                    kind: EvidenceNodeKind::AnalysisRun,
+                    label: "DSL analysis run".to_string(),
+                    element_refs: subject.into_iter().collect(),
+                    source_spans: Vec::new(),
+                    properties: BTreeMap::new(),
+                },
+                EvidenceNode {
+                    id: artifact_id.clone(),
+                    kind: EvidenceNodeKind::Artifact,
+                    label: "DSL analysis result".to_string(),
+                    element_refs: Vec::new(),
+                    source_spans: Vec::new(),
+                    properties: BTreeMap::new(),
+                },
+            ],
+            edges: vec![EvidenceEdge {
+                source_id: artifact_id,
+                target_id: evidence_id,
+                relation: EvidenceRelation::ProducedBy,
+            }],
+        },
+        diagnostics: Vec::new(),
+        limitations: Vec::new(),
+    }
+}
+
+fn status_from_result(result: &DslQueryResult) -> CapabilityRunStatus {
+    match verdict_value(result).and_then(Value::as_str) {
+        Some("pass") | Some("passed") | Some("satisfied") => CapabilityRunStatus::Passed,
+        Some("fail") | Some("failed") | Some("violated") => CapabilityRunStatus::Failed,
+        Some("inconclusive") | Some("unknown") => CapabilityRunStatus::Inconclusive,
+        _ => CapabilityRunStatus::Inconclusive,
+    }
+}
+
+fn insight_from_result(
+    run_id: &str,
+    subject: Option<SemanticElementRef>,
+    status: CapabilityRunStatus,
+    evidence_id: &str,
+    artifact: &SemanticArtifact,
+) -> Option<SemanticInsight> {
+    let (kind, polarity, severity, claim) = match status {
+        CapabilityRunStatus::Passed => (
+            InsightKind::CriterionPass,
+            InsightPolarity::Supports,
+            InsightSeverity::Info,
+            "Analysis criterion passed",
+        ),
+        CapabilityRunStatus::Failed => (
+            InsightKind::CriterionFail,
+            InsightPolarity::Weakens,
+            InsightSeverity::Error,
+            "Analysis criterion failed",
+        ),
+        _ => return None,
+    };
+    Some(SemanticInsight {
+        id: format!("insight.{run_id}.verdict"),
+        kind,
+        subject: subject.unwrap_or_else(|| SemanticElementRef {
+            element_id: "workspace".to_string(),
+            qualified_name: None,
+            label: Some("Workspace".to_string()),
+        }),
+        claim: claim.to_string(),
+        polarity,
+        severity,
+        confidence: InsightConfidence::High,
+        scope: InsightScope::Revision {
+            revision: crate::mutation::WorkspaceRevision {
+                fingerprint: artifact.digest.clone(),
+            },
+        },
+        evidence_ids: vec![evidence_id.to_string(), artifact.id.clone()],
+        source_spans: Vec::new(),
+        metrics: first_row_metrics(&artifact.payload),
+        assumptions: Vec::new(),
+        limitations: Vec::new(),
+    })
+}
+
+fn verdict_value(result: &DslQueryResult) -> Option<&Value> {
+    let column_index = result
+        .columns
+        .iter()
+        .position(|column| column == "verdict")?;
+    result.rows.first()?.get(column_index)
+}
+
+fn first_row_metrics(payload: &Value) -> BTreeMap<String, Value> {
+    let Some(columns) = payload.get("columns").and_then(Value::as_array) else {
+        return BTreeMap::new();
+    };
+    let Some(row) = payload
+        .get("rows")
+        .and_then(Value::as_array)
+        .and_then(|rows| rows.first())
+        .and_then(Value::as_array)
+    else {
+        return BTreeMap::new();
+    };
+    columns
+        .iter()
+        .zip(row)
+        .filter_map(|(column, value)| {
+            column
+                .as_str()
+                .map(|column| (column.to_string(), value.clone()))
+        })
+        .collect()
+}
+
+fn semantic_element_ref(graph: &Graph, element_id: &str) -> SemanticElementRef {
+    graph
+        .element_by_element_id(element_id)
+        .map(|element| SemanticElementRef {
+            element_id: element.element_id.clone(),
+            qualified_name: element
+                .properties
+                .get("qualified_name")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            label: element
+                .properties
+                .get("declared_name")
+                .or_else(|| element.properties.get("name"))
+                .and_then(Value::as_str)
+                .map(str::to_string),
+        })
+        .unwrap_or_else(|| SemanticElementRef {
+            element_id: element_id.to_string(),
+            qualified_name: None,
+            label: None,
+        })
+}
+
+fn value_digest(value: &Value) -> String {
+    let bytes = serde_json::to_vec(value).unwrap_or_default();
+    stable_digest([("dsl-analysis-artifact".as_bytes(), bytes.as_slice())])
 }
 
 impl Default for RhaiEngine {
@@ -451,6 +668,43 @@ mod tests {
             .unwrap();
         assert_eq!(result.columns, vec!["value"]);
         assert_eq!(result.rows[0][0], serde_json::json!(3.0));
+    }
+
+    #[test]
+    fn analysis_run_wraps_dsl_result_with_evidence() {
+        let engine = RhaiEngine::new();
+        let report = engine
+            .eval_analysis_run(
+                sample_graph(),
+                DslAnalysisRunSpec {
+                    run_id: "vehicle-mass".into(),
+                    capability_id: "mercurio.dsl.analysis".into(),
+                    subject_element_id: Some("type.Demo.Vehicle".into()),
+                    script: r#"
+                        let total = sum(model.parts().map(|p| p.property("mass_kg")));
+                        #{total_mass_kg: total, verdict: "pass"}
+                    "#
+                    .into(),
+                },
+            )
+            .unwrap();
+
+        assert_eq!(report.status, CapabilityRunStatus::Passed);
+        assert_eq!(report.artifacts.len(), 1);
+        assert_eq!(report.insights.len(), 1);
+        assert_eq!(report.insights[0].kind, InsightKind::CriterionPass);
+        assert_eq!(report.evidence.nodes.len(), 2);
+        assert!(
+            report
+                .evidence
+                .nodes
+                .iter()
+                .any(|node| node.kind == EvidenceNodeKind::AnalysisRun)
+        );
+        assert_eq!(
+            report.artifacts[0].payload["rows"][0][0],
+            serde_json::json!(16.5)
+        );
     }
 
     #[test]

--- a/crates/mercurio-foundation/src/dsl/stdlib.rs
+++ b/crates/mercurio-foundation/src/dsl/stdlib.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::sync::Arc;
 
-use rhai::{Dynamic, Engine, Map};
+use rhai::{Array, Dynamic, Engine, Map};
 
 use super::types::{DslElement, ElementSet, ModelContext};
 
@@ -17,6 +17,10 @@ pub fn register_stdlib(engine: &mut Engine) {
             .into_iter()
             .map(|(kind, count)| (kind.into(), Dynamic::from(count)))
             .collect()
+    });
+
+    engine.register_fn("sum", |values: Array| -> f64 {
+        values.into_iter().filter_map(dynamic_to_f64).sum()
     });
 
     engine.register_fn("all_parts", |context: &mut ModelContext| -> ElementSet {
@@ -73,4 +77,17 @@ pub fn register_stdlib(engine: &mut Engine) {
 
         depth
     });
+}
+
+fn dynamic_to_f64(value: Dynamic) -> Option<f64> {
+    if value.is::<i64>() {
+        return Some(value.cast::<i64>() as f64);
+    }
+    if value.is::<f64>() {
+        return Some(value.cast::<f64>());
+    }
+    if value.is::<String>() {
+        return value.cast::<String>().parse().ok();
+    }
+    None
 }

--- a/crates/mercurio-foundation/src/dsl/stdlib.rs
+++ b/crates/mercurio-foundation/src/dsl/stdlib.rs
@@ -1,0 +1,76 @@
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::sync::Arc;
+
+use rhai::{Dynamic, Engine, Map};
+
+use super::types::{DslElement, ElementSet, ModelContext};
+
+pub fn register_stdlib(engine: &mut Engine) {
+    engine.register_fn("count_by_kind", |set: &mut ElementSet| -> Map {
+        let mut counts = BTreeMap::<String, i64>::new();
+        for id in &set.ids {
+            if let Some(element) = set.graph.element(*id) {
+                *counts.entry(element.kind.as_ref().to_string()).or_default() += 1;
+            }
+        }
+        counts
+            .into_iter()
+            .map(|(kind, count)| (kind.into(), Dynamic::from(count)))
+            .collect()
+    });
+
+    engine.register_fn("all_parts", |context: &mut ModelContext| -> ElementSet {
+        context.parts()
+    });
+
+    engine.register_fn(
+        "reachable",
+        |element: &mut DslElement, relation: String| -> ElementSet {
+            let graph = Arc::clone(&element.graph);
+            let mut visited = BTreeSet::new();
+            let mut queue = VecDeque::new();
+            queue.push_back(element.id);
+
+            while let Some(id) = queue.pop_front() {
+                if !visited.insert(id) {
+                    continue;
+                }
+                for edge in graph.outgoing(id, &relation) {
+                    queue.push_back(edge.target);
+                }
+            }
+
+            visited.remove(&element.id);
+            ElementSet {
+                ids: visited.into_iter().collect(),
+                graph,
+            }
+        },
+    );
+
+    engine.register_fn("specialization_depth", |element: &mut DslElement| -> i64 {
+        let graph = Arc::clone(&element.graph);
+        let mut depth = 0i64;
+        let mut current = element.id;
+        let mut visited = BTreeSet::new();
+
+        loop {
+            if !visited.insert(current) {
+                break;
+            }
+            match graph
+                .outgoing(current, "specializes")
+                .next()
+                .map(|edge| edge.target)
+            {
+                Some(parent) => {
+                    depth += 1;
+                    current = parent;
+                }
+                None => break,
+            }
+        }
+
+        depth
+    });
+}

--- a/crates/mercurio-foundation/src/dsl/stdlib.rs
+++ b/crates/mercurio-foundation/src/dsl/stdlib.rs
@@ -23,6 +23,27 @@ pub fn register_stdlib(engine: &mut Engine) {
         values.into_iter().filter_map(dynamic_to_f64).sum()
     });
 
+    engine.register_fn("max", |values: Array| -> Dynamic {
+        numeric_extreme(values, f64::max)
+            .map(Dynamic::from)
+            .unwrap_or(Dynamic::UNIT)
+    });
+    engine.register_fn("max", |left: Dynamic, right: Dynamic| -> Dynamic {
+        binary_numeric_extreme(left, right, f64::max)
+            .map(Dynamic::from)
+            .unwrap_or(Dynamic::UNIT)
+    });
+    engine.register_fn("min", |values: Array| -> Dynamic {
+        numeric_extreme(values, f64::min)
+            .map(Dynamic::from)
+            .unwrap_or(Dynamic::UNIT)
+    });
+    engine.register_fn("min", |left: Dynamic, right: Dynamic| -> Dynamic {
+        binary_numeric_extreme(left, right, f64::min)
+            .map(Dynamic::from)
+            .unwrap_or(Dynamic::UNIT)
+    });
+
     engine.register_fn("all_parts", |context: &mut ModelContext| -> ElementSet {
         context.parts()
     });
@@ -90,4 +111,19 @@ fn dynamic_to_f64(value: Dynamic) -> Option<f64> {
         return value.cast::<String>().parse().ok();
     }
     None
+}
+
+fn numeric_extreme(values: Array, reducer: fn(f64, f64) -> f64) -> Option<f64> {
+    values
+        .into_iter()
+        .filter_map(dynamic_to_f64)
+        .reduce(reducer)
+}
+
+fn binary_numeric_extreme(
+    left: Dynamic,
+    right: Dynamic,
+    reducer: fn(f64, f64) -> f64,
+) -> Option<f64> {
+    Some(reducer(dynamic_to_f64(left)?, dynamic_to_f64(right)?))
 }

--- a/crates/mercurio-foundation/src/dsl/types.rs
+++ b/crates/mercurio-foundation/src/dsl/types.rs
@@ -186,11 +186,35 @@ impl DslElement {
     }
 
     pub fn property(&mut self, name: String) -> Dynamic {
-        self.elem()
+        if let Some(value) = self
+            .elem()
             .and_then(|element| element.properties.get(&name))
             .cloned()
-            .map(serde_json_to_dynamic)
-            .unwrap_or(Dynamic::UNIT)
+        {
+            return serde_json_to_dynamic(value);
+        }
+
+        self.owned_feature_property(&name).unwrap_or(Dynamic::UNIT)
+    }
+
+    fn owned_feature_property(&self, name: &str) -> Option<Dynamic> {
+        for relation in ["features", "members"] {
+            for edge in self.graph.outgoing(self.id, relation) {
+                let Some(feature) = self.graph.element(edge.target) else {
+                    continue;
+                };
+                if string_property(feature, "declared_name") != Some(name) {
+                    continue;
+                }
+                if let Some(value) = literal_expression_value(feature) {
+                    return Some(serde_json_to_dynamic(value));
+                }
+                if let Some(value) = feature.properties.get("value").cloned() {
+                    return Some(serde_json_to_dynamic(value));
+                }
+            }
+        }
+        None
     }
 
     pub fn outgoing(&mut self, relation: String) -> ElementSet {
@@ -373,6 +397,19 @@ fn element_property_json(element: &Element, column: &str) -> Value {
             .get(property)
             .cloned()
             .unwrap_or(Value::Null),
+    }
+}
+
+fn string_property<'a>(element: &'a Element, name: &str) -> Option<&'a str> {
+    element.properties.get(name).and_then(Value::as_str)
+}
+
+fn literal_expression_value(element: &Element) -> Option<Value> {
+    let expression = element.properties.get("expression_ir")?;
+    if expression.get("kind").and_then(Value::as_str) == Some("literal") {
+        expression.get("value").cloned()
+    } else {
+        None
     }
 }
 

--- a/crates/mercurio-foundation/src/dsl/types.rs
+++ b/crates/mercurio-foundation/src/dsl/types.rs
@@ -1,0 +1,418 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use rhai::{Array, Dynamic, Engine, EvalAltResult, FnPtr, Map, NativeCallContext};
+use serde_json::Value;
+
+use super::DslQueryResult;
+use crate::graph::{Element, Graph, NodeId};
+use crate::ir::{KirDocument, KirElement};
+
+#[derive(Debug, Clone)]
+pub struct ModelContext {
+    graph: Arc<Graph>,
+}
+
+impl ModelContext {
+    pub fn new(graph: Arc<Graph>) -> Self {
+        Self { graph }
+    }
+
+    pub fn parts(&mut self) -> ElementSet {
+        let ids = self
+            .graph
+            .elements()
+            .iter()
+            .filter(|element| element.layer == 2)
+            .map(|element| element.id)
+            .collect();
+        ElementSet {
+            ids,
+            graph: Arc::clone(&self.graph),
+        }
+    }
+
+    pub fn elements(&mut self) -> ElementSet {
+        let ids = self
+            .graph
+            .elements()
+            .iter()
+            .map(|element| element.id)
+            .collect();
+        ElementSet {
+            ids,
+            graph: Arc::clone(&self.graph),
+        }
+    }
+
+    pub fn element(&mut self, element_id: String) -> Dynamic {
+        match self.graph.element_by_element_id(&element_id) {
+            Some(element) => Dynamic::from(DslElement {
+                id: element.id,
+                graph: Arc::clone(&self.graph),
+            }),
+            None => Dynamic::UNIT,
+        }
+    }
+
+    pub fn match_pattern(&mut self, pattern: String) -> Result<Array, Box<EvalAltResult>> {
+        let query = crate::query::parse_query(&pattern).map_err(|error| {
+            Box::new(EvalAltResult::ErrorRuntime(
+                error.to_string().into(),
+                rhai::Position::NONE,
+            ))
+        })?;
+        let document = graph_to_kir_document(&self.graph);
+        let result_set = crate::query::QueryEngine::new(&document)
+            .execute(&query)
+            .map_err(|error| {
+                Box::new(EvalAltResult::ErrorRuntime(
+                    error.to_string().into(),
+                    rhai::Position::NONE,
+                ))
+            })?;
+
+        Ok(result_set
+            .rows
+            .into_iter()
+            .map(|row| {
+                let map = row
+                    .into_iter()
+                    .map(|(key, value)| (key.into(), serde_json_to_dynamic(value)))
+                    .collect::<Map>();
+                Dynamic::from(map)
+            })
+            .collect())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ElementSet {
+    pub(crate) ids: Vec<NodeId>,
+    pub(crate) graph: Arc<Graph>,
+}
+
+impl ElementSet {
+    pub fn count(&mut self) -> i64 {
+        self.ids.len() as i64
+    }
+
+    pub fn first(&mut self) -> Dynamic {
+        match self.ids.first().copied() {
+            Some(id) => Dynamic::from(DslElement {
+                id,
+                graph: Arc::clone(&self.graph),
+            }),
+            None => Dynamic::UNIT,
+        }
+    }
+
+    pub fn collect_elements(&mut self) -> Array {
+        self.ids
+            .iter()
+            .copied()
+            .map(|id| {
+                Dynamic::from(DslElement {
+                    id,
+                    graph: Arc::clone(&self.graph),
+                })
+            })
+            .collect()
+    }
+
+    pub fn select_fields(&mut self, fields: Array) -> DslQueryResult {
+        let columns = fields
+            .into_iter()
+            .filter_map(|field| field.try_cast::<String>())
+            .collect::<Vec<_>>();
+        let rows = self
+            .ids
+            .iter()
+            .filter_map(|id| self.graph.element(*id))
+            .map(|element| {
+                columns
+                    .iter()
+                    .map(|column| element_property_json(element, column))
+                    .collect()
+            })
+            .collect();
+
+        DslQueryResult { columns, rows }
+    }
+
+    pub fn to_query_result(&self) -> DslQueryResult {
+        let columns = vec!["element_id".into(), "kind".into(), "layer".into()];
+        let rows = self
+            .ids
+            .iter()
+            .filter_map(|id| self.graph.element(*id))
+            .map(|element| {
+                vec![
+                    Value::String(element.element_id.clone()),
+                    Value::String(element.kind.as_ref().to_string()),
+                    Value::from(element.layer),
+                ]
+            })
+            .collect();
+        DslQueryResult { columns, rows }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DslElement {
+    pub(crate) id: NodeId,
+    pub(crate) graph: Arc<Graph>,
+}
+
+impl DslElement {
+    fn elem(&self) -> Option<&Element> {
+        self.graph.element(self.id)
+    }
+
+    pub fn get_id(&mut self) -> String {
+        self.elem()
+            .map(|element| element.element_id.clone())
+            .unwrap_or_default()
+    }
+
+    pub fn get_kind(&mut self) -> String {
+        self.elem()
+            .map(|element| element.kind.as_ref().to_string())
+            .unwrap_or_default()
+    }
+
+    pub fn get_layer(&mut self) -> i64 {
+        self.elem().map_or(0, |element| i64::from(element.layer))
+    }
+
+    pub fn property(&mut self, name: String) -> Dynamic {
+        self.elem()
+            .and_then(|element| element.properties.get(&name))
+            .cloned()
+            .map(serde_json_to_dynamic)
+            .unwrap_or(Dynamic::UNIT)
+    }
+
+    pub fn outgoing(&mut self, relation: String) -> ElementSet {
+        let ids = self
+            .graph
+            .outgoing(self.id, &relation)
+            .map(|edge| edge.target)
+            .collect();
+        ElementSet {
+            ids,
+            graph: Arc::clone(&self.graph),
+        }
+    }
+
+    pub fn incoming(&mut self, relation: String) -> ElementSet {
+        let ids = self
+            .graph
+            .incoming(self.id, &relation)
+            .map(|edge| edge.source)
+            .collect();
+        ElementSet {
+            ids,
+            graph: Arc::clone(&self.graph),
+        }
+    }
+
+    pub fn outgoing_edges(&mut self) -> Array {
+        self.graph
+            .outgoing_edges(self.id)
+            .map(|edge| {
+                Dynamic::from(DslEdge {
+                    source: edge.source,
+                    target: edge.target,
+                    relation: edge.relation.as_ref().to_string(),
+                    graph: Arc::clone(&self.graph),
+                })
+            })
+            .collect()
+    }
+
+    pub fn incoming_edges(&mut self) -> Array {
+        self.graph
+            .incoming_edges(self.id)
+            .map(|edge| {
+                Dynamic::from(DslEdge {
+                    source: edge.source,
+                    target: edge.target,
+                    relation: edge.relation.as_ref().to_string(),
+                    graph: Arc::clone(&self.graph),
+                })
+            })
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DslEdge {
+    pub(crate) source: NodeId,
+    pub(crate) target: NodeId,
+    pub(crate) relation: String,
+    pub(crate) graph: Arc<Graph>,
+}
+
+impl DslEdge {
+    pub fn get_relation(&mut self) -> String {
+        self.relation.clone()
+    }
+
+    pub fn get_source_id(&mut self) -> String {
+        self.graph
+            .element_id(self.source)
+            .map(str::to_string)
+            .unwrap_or_default()
+    }
+
+    pub fn get_target_id(&mut self) -> String {
+        self.graph
+            .element_id(self.target)
+            .map(str::to_string)
+            .unwrap_or_default()
+    }
+
+    pub fn source_element(&mut self) -> Dynamic {
+        Dynamic::from(DslElement {
+            id: self.source,
+            graph: Arc::clone(&self.graph),
+        })
+    }
+
+    pub fn target_element(&mut self) -> Dynamic {
+        Dynamic::from(DslElement {
+            id: self.target,
+            graph: Arc::clone(&self.graph),
+        })
+    }
+}
+
+pub fn register_types(engine: &mut Engine) {
+    engine
+        .register_type_with_name::<ModelContext>("ModelContext")
+        .register_fn("parts", ModelContext::parts)
+        .register_fn("elements", ModelContext::elements)
+        .register_fn("element", ModelContext::element)
+        .register_fn("match_pattern", ModelContext::match_pattern);
+
+    engine
+        .register_type_with_name::<ElementSet>("ElementSet")
+        .register_fn("count", ElementSet::count)
+        .register_fn("first", ElementSet::first)
+        .register_fn("collect", ElementSet::collect_elements)
+        .register_fn("select", ElementSet::select_fields)
+        .register_fn("where", filter_where)
+        .register_fn("map", map_elements);
+
+    engine
+        .register_type_with_name::<DslElement>("Element")
+        .register_get("id", DslElement::get_id)
+        .register_get("kind", DslElement::get_kind)
+        .register_get("layer", DslElement::get_layer)
+        .register_fn("property", DslElement::property)
+        .register_fn("outgoing", DslElement::outgoing)
+        .register_fn("incoming", DslElement::incoming)
+        .register_fn("outgoing_edges", DslElement::outgoing_edges)
+        .register_fn("incoming_edges", DslElement::incoming_edges);
+
+    engine
+        .register_type_with_name::<DslEdge>("Edge")
+        .register_get("relation", DslEdge::get_relation)
+        .register_get("source_id", DslEdge::get_source_id)
+        .register_get("target_id", DslEdge::get_target_id)
+        .register_fn("source", DslEdge::source_element)
+        .register_fn("target", DslEdge::target_element);
+}
+
+fn filter_where(
+    context: NativeCallContext,
+    set: &mut ElementSet,
+    predicate: FnPtr,
+) -> Result<ElementSet, Box<EvalAltResult>> {
+    let mut kept = Vec::new();
+    for id in &set.ids {
+        let element = DslElement {
+            id: *id,
+            graph: Arc::clone(&set.graph),
+        };
+        if predicate.call_within_context::<bool>(&context, (element,))? {
+            kept.push(*id);
+        }
+    }
+    Ok(ElementSet {
+        ids: kept,
+        graph: Arc::clone(&set.graph),
+    })
+}
+
+fn map_elements(
+    context: NativeCallContext,
+    set: &mut ElementSet,
+    mapper: FnPtr,
+) -> Result<Array, Box<EvalAltResult>> {
+    set.ids
+        .iter()
+        .map(|id| {
+            let element = DslElement {
+                id: *id,
+                graph: Arc::clone(&set.graph),
+            };
+            mapper.call_within_context::<Dynamic>(&context, (element,))
+        })
+        .collect()
+}
+
+fn element_property_json(element: &Element, column: &str) -> Value {
+    match column {
+        "id" | "element_id" => Value::String(element.element_id.clone()),
+        "kind" => Value::String(element.kind.as_ref().to_string()),
+        "layer" => Value::from(element.layer),
+        property => element
+            .properties
+            .get(property)
+            .cloned()
+            .unwrap_or(Value::Null),
+    }
+}
+
+fn graph_to_kir_document(graph: &Graph) -> KirDocument {
+    KirDocument {
+        metadata: BTreeMap::new(),
+        elements: graph
+            .elements()
+            .iter()
+            .map(|element| KirElement {
+                id: element.element_id.clone(),
+                kind: element.kind.as_ref().to_string(),
+                layer: element.layer,
+                properties: element.properties.to_btree_map(),
+            })
+            .collect(),
+    }
+}
+
+fn serde_json_to_dynamic(value: Value) -> Dynamic {
+    match value {
+        Value::String(value) => Dynamic::from(value),
+        Value::Number(value) => value
+            .as_i64()
+            .map(Dynamic::from)
+            .or_else(|| value.as_f64().map(Dynamic::from))
+            .unwrap_or(Dynamic::UNIT),
+        Value::Bool(value) => Dynamic::from(value),
+        Value::Array(values) => Dynamic::from(
+            values
+                .into_iter()
+                .map(serde_json_to_dynamic)
+                .collect::<Array>(),
+        ),
+        Value::Object(values) => Dynamic::from(
+            values
+                .into_iter()
+                .map(|(key, value)| (key.into(), serde_json_to_dynamic(value)))
+                .collect::<Map>(),
+        ),
+        Value::Null => Dynamic::UNIT,
+    }
+}

--- a/crates/mercurio-foundation/src/lib.rs
+++ b/crates/mercurio-foundation/src/lib.rs
@@ -177,7 +177,9 @@ pub use derived::{
     DerivedPropertyValue, builtin_core_derived_feature_manifest, derived_properties,
     derived_property, manifest_from_metadata,
 };
-pub use dsl::{DslError, DslFieldSchema, DslQueryResult, DslSchema, RhaiEngine};
+pub use dsl::{
+    DslAnalysisRunSpec, DslError, DslFieldSchema, DslQueryResult, DslSchema, RhaiEngine,
+};
 pub use element_view::ElementView;
 pub use expression::{
     BinaryExpressionOp, ExpressionEvaluationContext, ExpressionEvaluationError, ExpressionIr,

--- a/crates/mercurio-foundation/src/lib.rs
+++ b/crates/mercurio-foundation/src/lib.rs
@@ -86,6 +86,7 @@ pub mod metamodel {
         query_element_attributes,
     };
 }
+pub mod dsl;
 #[doc(hidden)]
 pub mod mpack;
 #[doc(hidden)]
@@ -176,6 +177,7 @@ pub use derived::{
     DerivedPropertyValue, builtin_core_derived_feature_manifest, derived_properties,
     derived_property, manifest_from_metadata,
 };
+pub use dsl::{DslError, DslFieldSchema, DslQueryResult, DslSchema, RhaiEngine};
 pub use element_view::ElementView;
 pub use expression::{
     BinaryExpressionOp, ExpressionEvaluationContext, ExpressionEvaluationError, ExpressionIr,

--- a/crates/mercurio-foundation/src/library.rs
+++ b/crates/mercurio-foundation/src/library.rs
@@ -615,9 +615,15 @@ impl LibraryProviderConfig {
             Self::PackageSetDirectory { path, entry } => {
                 let source_path = resolve_provider_path(path, base_dir);
                 let package_index = build_kpar_package_index(&source_path)?;
+                let entry_key = package_index.resolve(entry, None).ok_or_else(|| {
+                    KirError::Model(format!(
+                        "package-set entry '{entry}' not found in {}",
+                        source_path.display()
+                    ))
+                })?;
                 let source_version = package_index
-                    .resolve(entry, None)
-                    .and_then(|entry_key| package_index.packages.get(&entry_key))
+                    .packages
+                    .get(&entry_key)
                     .and_then(|package| package.metadata.as_ref())
                     .and_then(|metadata| metadata.version.clone());
                 Ok(LibrarySourceFingerprint {
@@ -3275,6 +3281,12 @@ mod tests {
         }
         .resolve("systems")
         .unwrap();
+        let fingerprint = LibraryProviderConfig::PackageSetDirectory {
+            path: package_dir.display().to_string(),
+            entry: "https://www.omg.org/spec/Model/20250201/Systems-Library.kpar".to_string(),
+        }
+        .source_fingerprint("systems", None)
+        .unwrap();
 
         assert_eq!(artifact.source_kind, "package_set_directory");
         assert_eq!(
@@ -3282,6 +3294,11 @@ mod tests {
                 .cache_metadata
                 .as_ref()
                 .and_then(|metadata| metadata.source_version.as_deref()),
+            Some("2.0.0")
+        );
+        assert_eq!(fingerprint.source_kind, "package_set_directory");
+        assert_eq!(
+            fingerprint.cache_metadata.source_version.as_deref(),
             Some("2.0.0")
         );
         assert!(

--- a/crates/mercurio-model/src/graph.rs
+++ b/crates/mercurio-model/src/graph.rs
@@ -673,30 +673,23 @@ mod tests {
     #[test]
     fn representative_example_projects_core_graph_edges() {
         let graph = Graph::from_document(KirDocument::representative_example().unwrap()).unwrap();
-        let vehicle = graph.node_id("type.Example.Vehicle").unwrap();
         let package = graph.node_id("pkg.Example").unwrap();
-        let controller_feature = graph.node_id("feature.Example.Vehicle.controller").unwrap();
+        let activity = graph.node_id("activity.Example.Startup").unwrap();
 
         assert!(
             graph
-                .element_by_element_id("req.Example.SafeStart")
+                .element_by_element_id("activity.Example.Startup")
                 .is_some()
         );
         assert!(
             graph
-                .outgoing(vehicle, "owner")
+                .outgoing(activity, "owner")
                 .any(|edge| edge.target == package)
         );
         assert!(
             graph
-                .outgoing(vehicle, "features")
-                .any(|edge| edge.target == controller_feature)
-        );
-        assert!(
-            graph
-                .outgoing(vehicle, "specializes")
-                .filter_map(|edge| graph.element_id(edge.target))
-                .any(|id| id == "Model::Kernel::ComponentDefinition")
+                .outgoing(package, "members")
+                .any(|edge| edge.target == activity)
         );
     }
 }

--- a/crates/mercurio-runtime/src/runtime.rs
+++ b/crates/mercurio-runtime/src/runtime.rs
@@ -935,21 +935,19 @@ mod tests {
         let runtime =
             Runtime::from_document(KirDocument::representative_example().unwrap()).unwrap();
 
-        let subtypes = runtime
-            .get_subtypes("Model::Kernel::ComponentDefinition")
-            .unwrap();
-        assert!(subtypes.value.contains(&"type.Example.Vehicle".to_string()));
         assert!(
-            subtypes
-                .value
-                .contains(&"type.Example.Controller".to_string())
+            runtime
+                .graph()
+                .element_by_element_id("activity.Example.Startup")
+                .is_some()
         );
-
-        let features = runtime.get_features("type.Example.Vehicle").unwrap();
+        let package = runtime.graph().node_id("pkg.Example").unwrap();
+        let activity = runtime.graph().node_id("activity.Example.Startup").unwrap();
         assert!(
-            features
-                .value
-                .contains(&"feature.Example.Vehicle.controller".to_string())
+            runtime
+                .graph()
+                .outgoing(package, "members")
+                .any(|edge| edge.target == activity)
         );
     }
 

--- a/crates/mercurio-views/src/lib.rs
+++ b/crates/mercurio-views/src/lib.rs
@@ -1631,13 +1631,255 @@ fn default_layout_direction() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mercurio_core::{KirDocument, KirElement};
+    use serde_json::json;
+    use std::collections::BTreeMap;
 
     fn sample_graph() -> (Graph, MetamodelAttributeRegistry) {
-        let document =
-            mercurio_core::KirDocument::representative_example().expect("fixture should parse");
+        let document = view_fixture_document();
         let graph = Graph::from_document(document).expect("sample graph should be valid");
         let registry = MetamodelAttributeRegistry::build(&graph);
         (graph, registry)
+    }
+
+    fn view_fixture_document() -> KirDocument {
+        fn element(
+            id: &str,
+            kind: &str,
+            layer: u8,
+            properties: BTreeMap<String, Value>,
+        ) -> KirElement {
+            KirElement {
+                id: id.to_string(),
+                kind: kind.to_string(),
+                layer,
+                properties,
+            }
+        }
+
+        KirDocument {
+            metadata: BTreeMap::new(),
+            elements: vec![
+                element(
+                    "Comment",
+                    "Metaclass",
+                    1,
+                    BTreeMap::from([
+                        ("declared_name".to_string(), json!("Comment")),
+                        (
+                            "features".to_string(),
+                            json!(["metafeature.Comment.body", "metafeature.Comment.locale"]),
+                        ),
+                    ]),
+                ),
+                element(
+                    "metafeature.Comment.body",
+                    "MetamodelFeature",
+                    1,
+                    BTreeMap::from([
+                        ("owner".to_string(), json!("Comment")),
+                        ("kir_property".to_string(), json!("body")),
+                        ("type_label".to_string(), json!("String")),
+                    ]),
+                ),
+                element(
+                    "metafeature.Comment.locale",
+                    "MetamodelFeature",
+                    1,
+                    BTreeMap::from([
+                        ("owner".to_string(), json!("Comment")),
+                        ("kir_property".to_string(), json!("locale")),
+                        ("type_label".to_string(), json!("String")),
+                    ]),
+                ),
+                element(
+                    "Model::Kernel::ComponentDefinition",
+                    "PartDefinition",
+                    1,
+                    BTreeMap::from([
+                        ("declared_name".to_string(), json!("ComponentDefinition")),
+                        (
+                            "qualified_name".to_string(),
+                            json!("Model::Kernel::ComponentDefinition"),
+                        ),
+                    ]),
+                ),
+                element(
+                    "pkg.Example",
+                    "Package",
+                    2,
+                    BTreeMap::from([
+                        ("declared_name".to_string(), json!("Example")),
+                        ("qualified_name".to_string(), json!("Example")),
+                        (
+                            "members".to_string(),
+                            json!([
+                                "type.Example.Vehicle",
+                                "state.Example.DriveMode",
+                                "activity.Example.Startup",
+                                "req.Example.SafeStart",
+                                "comment.Example.Note",
+                                "comment.Example.LocalizedNote"
+                            ]),
+                        ),
+                    ]),
+                ),
+                element(
+                    "type.Example.Vehicle",
+                    "PartDefinition",
+                    2,
+                    BTreeMap::from([
+                        ("declared_name".to_string(), json!("Vehicle")),
+                        ("qualified_name".to_string(), json!("Example.Vehicle")),
+                        ("owner".to_string(), json!("pkg.Example")),
+                        (
+                            "specializes".to_string(),
+                            json!(["Model::Kernel::ComponentDefinition"]),
+                        ),
+                    ]),
+                ),
+                element(
+                    "feature.Example.Vehicle.controller",
+                    "PartUsage",
+                    2,
+                    BTreeMap::from([
+                        ("declared_name".to_string(), json!("controller")),
+                        (
+                            "qualified_name".to_string(),
+                            json!("Example.Vehicle.controller"),
+                        ),
+                        ("owner".to_string(), json!("type.Example.Vehicle")),
+                        ("owning_type".to_string(), json!("type.Example.Vehicle")),
+                    ]),
+                ),
+                element(
+                    "state.Example.DriveMode",
+                    "StateUsage",
+                    2,
+                    BTreeMap::from([
+                        ("declared_name".to_string(), json!("DriveMode")),
+                        ("qualified_name".to_string(), json!("Example.DriveMode")),
+                        ("owner".to_string(), json!("pkg.Example")),
+                        ("source".to_string(), json!("state.Example.Parked")),
+                        ("target".to_string(), json!("state.Example.Driving")),
+                    ]),
+                ),
+                element(
+                    "state.Example.Parked",
+                    "StateUsage",
+                    2,
+                    BTreeMap::from([
+                        ("declared_name".to_string(), json!("Parked")),
+                        ("qualified_name".to_string(), json!("Example.Parked")),
+                        ("owner".to_string(), json!("state.Example.DriveMode")),
+                    ]),
+                ),
+                element(
+                    "state.Example.Driving",
+                    "StateUsage",
+                    2,
+                    BTreeMap::from([
+                        ("declared_name".to_string(), json!("Driving")),
+                        ("qualified_name".to_string(), json!("Example.Driving")),
+                        ("owner".to_string(), json!("state.Example.DriveMode")),
+                    ]),
+                ),
+                element(
+                    "activity.Example.Startup",
+                    "ActivityUsage",
+                    2,
+                    BTreeMap::from([
+                        ("declared_name".to_string(), json!("Startup")),
+                        ("qualified_name".to_string(), json!("Example.Startup")),
+                        ("owner".to_string(), json!("pkg.Example")),
+                    ]),
+                ),
+                element(
+                    "action.Example.Startup.Validate",
+                    "ActionUsage",
+                    2,
+                    BTreeMap::from([
+                        ("declared_name".to_string(), json!("Validate")),
+                        (
+                            "qualified_name".to_string(),
+                            json!("Example.Startup.Validate"),
+                        ),
+                        ("owner".to_string(), json!("activity.Example.Startup")),
+                    ]),
+                ),
+                element(
+                    "flow.Example.Startup.Validate",
+                    "ControlFlow",
+                    2,
+                    BTreeMap::from([
+                        ("declared_name".to_string(), json!("ValidateFlow")),
+                        (
+                            "qualified_name".to_string(),
+                            json!("Example.Startup.ValidateFlow"),
+                        ),
+                        ("owner".to_string(), json!("activity.Example.Startup")),
+                        ("source".to_string(), json!("activity.Example.Startup")),
+                        (
+                            "target".to_string(),
+                            json!("action.Example.Startup.Validate"),
+                        ),
+                    ]),
+                ),
+                element(
+                    "req.Example.SafeStart",
+                    "RequirementUsage",
+                    2,
+                    BTreeMap::from([
+                        ("declared_name".to_string(), json!("SafeStart")),
+                        ("qualified_name".to_string(), json!("Example.SafeStart")),
+                        ("owner".to_string(), json!("pkg.Example")),
+                        ("requirement_id".to_string(), json!("REQ-001")),
+                        (
+                            "text".to_string(),
+                            json!("The vehicle shall prevent unsafe starts."),
+                        ),
+                        (
+                            "metadata".to_string(),
+                            json!({
+                                "Review": {
+                                    "properties": {
+                                        "status": "approved",
+                                        "owner": "Foundation Team",
+                                        "reviewDate": "2026-06-03"
+                                    }
+                                }
+                            }),
+                        ),
+                    ]),
+                ),
+                element(
+                    "comment.Example.Note",
+                    "Comment",
+                    2,
+                    BTreeMap::from([
+                        ("declared_name".to_string(), json!("Note")),
+                        ("qualified_name".to_string(), json!("Example.Note")),
+                        ("owner".to_string(), json!("pkg.Example")),
+                        ("metatype".to_string(), json!("Comment")),
+                        ("body".to_string(), json!("Primary model note.")),
+                        ("locale".to_string(), json!("en-US")),
+                    ]),
+                ),
+                element(
+                    "comment.Example.LocalizedNote",
+                    "Comment",
+                    2,
+                    BTreeMap::from([
+                        ("declared_name".to_string(), json!("LocalizedNote")),
+                        ("qualified_name".to_string(), json!("Example.LocalizedNote")),
+                        ("owner".to_string(), json!("pkg.Example")),
+                        ("metatype".to_string(), json!("Comment")),
+                        ("body".to_string(), json!("Localized model note.")),
+                        ("locale".to_string(), json!("fr-FR")),
+                    ]),
+                ),
+            ],
+        }
     }
 
     fn render_sample(spec: DiagramSpecDto) -> DiagramViewDto {


### PR DESCRIPTION
## Summary
- adds the Rhai-backed model DSL query engine
- adds stdlib helpers for sum, max, and min
- wraps DSL analysis results as CapabilityRunReport artifacts, evidence, and insights
- fixes package-set fingerprint fallback validation and stale representative fixture tests encountered during broader validation

## Validation
- PASS: cargo test -p mercurio-foundation library::tests::stdlib_locator_ -- --test-threads=1 --nocapture
- PASS: cargo test -p mercurio-model graph::tests::representative_example_projects_core_graph_edges -- --exact --nocapture
- PASS: cargo test -p mercurio-runtime runtime::tests::representative_example_builds_runtime_indexes -- --exact --nocapture
- PASS: cargo test -p mercurio-foundation DSL tests as part of targeted foundation checks
- BLOCKED: cargo test still fails in mercurio-views because multiple tests expect the old rich KirDocument::representative_example fixture while the current fixture is minimal package/activity content. This is separate from the DSL changes but blocks full workspace green.

## Coordination
Pair with mercurio-product PR for API, Tauri, transport, and Analysis dock wiring.