### PR TITLE
Enforce KIR contract adoption

### DIFF
--- a/crates/mercurio-foundation/src/capability.rs
+++ b/crates/mercurio-foundation/src/capability.rs
@@ -306,6 +306,8 @@ pub struct SemanticElementRef {
     pub qualified_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub semantic_anchor: Option<SemanticAnchor>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -569,7 +571,7 @@ impl SemanticWorkspaceSnapshot {
         kir: KirDocument,
         profile_id: Option<String>,
     ) -> Result<Self, CapabilityError> {
-        kir.validate()?;
+        kir.validate_persisted()?;
         let validation_report = validate_kir_semantics(&kir)
             .map_err(|err| CapabilityError::Workspace(err.to_string()))?;
         let revision = workspace_revision_for_kir_document(&kir)?;
@@ -646,11 +648,16 @@ impl SemanticWorkspaceSnapshot {
 
     pub fn element_ref(&self, element_id: &str) -> SemanticElementRef {
         self.element(element_id)
-            .map(element_ref)
+            .map(|element| {
+                let mut reference = element_ref(element);
+                reference.semantic_anchor = self.anchor_for_element(element_id).ok().flatten();
+                reference
+            })
             .unwrap_or_else(|| SemanticElementRef {
                 element_id: element_id.to_string(),
                 qualified_name: None,
                 label: None,
+                semantic_anchor: None,
             })
     }
 
@@ -1563,6 +1570,7 @@ fn inspect_workspace_summary(
             element_id: "workspace".to_string(),
             qualified_name: None,
             label: Some("Workspace".to_string()),
+            semantic_anchor: None,
         },
         claim: format!(
             "Workspace inspection found {scoped_count} elements in analysis scope `{}` from {authored_count} authored elements, {library_count} library elements, and {metamodel_count} metamodel elements.",
@@ -1686,6 +1694,7 @@ fn inspect_query(
                 element_id: "workspace".to_string(),
                 qualified_name: None,
                 label: Some("Workspace".to_string()),
+                semantic_anchor: None,
             },
             claim: format!("Inspection query `{query}` matched no compiled KIR elements."),
             polarity: InsightPolarity::Neutral,
@@ -1974,6 +1983,7 @@ fn element_ref(element: &crate::graph::Element) -> SemanticElementRef {
                     .find(|part| !part.is_empty())
                     .map(ToOwned::to_owned)
             }),
+        semantic_anchor: None,
     }
 }
 
@@ -2137,26 +2147,29 @@ mod tests {
 
     #[test]
     fn registry_lists_and_runs_graph_impact() {
-        let workspace = SemanticWorkspaceSnapshot::from_document(KirDocument {
-            metadata: BTreeMap::new(),
-            elements: vec![
-                KirElement {
-                    id: "pkg.Demo".to_string(),
-                    kind: "Model::Package".to_string(),
-                    layer: 2,
-                    properties: BTreeMap::from([(
-                        "members".to_string(),
-                        Value::Array(vec![Value::String("type.Vehicle".to_string())]),
-                    )]),
-                },
-                KirElement {
-                    id: "type.Vehicle".to_string(),
-                    kind: "Model::PartDefinition".to_string(),
-                    layer: 2,
-                    properties: BTreeMap::new(),
-                },
-            ],
-        })
+        let workspace = SemanticWorkspaceSnapshot::from_document(
+            KirDocument {
+                metadata: BTreeMap::new(),
+                elements: vec![
+                    KirElement {
+                        id: "pkg.Demo".to_string(),
+                        kind: "Model::Package".to_string(),
+                        layer: 2,
+                        properties: BTreeMap::from([(
+                            "members".to_string(),
+                            Value::Array(vec![Value::String("type.Vehicle".to_string())]),
+                        )]),
+                    },
+                    KirElement {
+                        id: "type.Vehicle".to_string(),
+                        kind: "Model::PartDefinition".to_string(),
+                        layer: 2,
+                        properties: BTreeMap::new(),
+                    },
+                ],
+            }
+            .normalized_for_persistence(),
+        )
         .unwrap();
         let registry = CapabilityRegistry::with_foundation_builtins();
 
@@ -2192,34 +2205,37 @@ mod tests {
 
     #[test]
     fn model_inspection_resolves_metamodel_element_attributes() {
-        let workspace = SemanticWorkspaceSnapshot::from_document(KirDocument {
-            metadata: BTreeMap::new(),
-            elements: vec![
-                KirElement {
-                    id: "KerML::Root::Element".to_string(),
-                    kind: "Metaclass".to_string(),
-                    layer: 1,
-                    properties: BTreeMap::from([(
-                        "declared_name".to_string(),
-                        Value::String("Element".to_string()),
-                    )]),
-                },
-                metamodel_feature(
-                    "KerML::Root::Element::declaredName",
-                    "KerML::Root::Element",
-                    "declaredName",
-                    "declared_name",
-                    Some("String"),
-                ),
-                metamodel_feature(
-                    "KerML::Root::Element::ownedElement",
-                    "KerML::Root::Element",
-                    "ownedElement",
-                    "ownedElement",
-                    None,
-                ),
-            ],
-        })
+        let workspace = SemanticWorkspaceSnapshot::from_document(
+            KirDocument {
+                metadata: BTreeMap::new(),
+                elements: vec![
+                    KirElement {
+                        id: "KerML::Root::Element".to_string(),
+                        kind: "Metaclass".to_string(),
+                        layer: 1,
+                        properties: BTreeMap::from([(
+                            "declared_name".to_string(),
+                            Value::String("Element".to_string()),
+                        )]),
+                    },
+                    metamodel_feature(
+                        "KerML::Root::Element::declaredName",
+                        "KerML::Root::Element",
+                        "declaredName",
+                        "declared_name",
+                        Some("String"),
+                    ),
+                    metamodel_feature(
+                        "KerML::Root::Element::ownedElement",
+                        "KerML::Root::Element",
+                        "ownedElement",
+                        "ownedElement",
+                        None,
+                    ),
+                ],
+            }
+            .normalized_for_persistence(),
+        )
         .unwrap();
         let registry = CapabilityRegistry::with_foundation_builtins();
 
@@ -2268,51 +2284,54 @@ mod tests {
 
     #[test]
     fn model_inspection_analysis_scope_filters_workspace_inventory() {
-        let workspace = SemanticWorkspaceSnapshot::from_document(KirDocument {
-            metadata: BTreeMap::new(),
-            elements: vec![
-                KirElement {
-                    id: "Demo::Vehicle".to_string(),
-                    kind: "PartDefinition".to_string(),
-                    layer: 0,
-                    properties: BTreeMap::from([(
-                        "declared_name".to_string(),
-                        Value::String("Vehicle".to_string()),
-                    )]),
-                },
-                KirElement {
-                    id: "ScalarValues::Real".to_string(),
-                    kind: "DataType".to_string(),
-                    layer: 1,
-                    properties: BTreeMap::from([
-                        (
+        let workspace = SemanticWorkspaceSnapshot::from_document(
+            KirDocument {
+                metadata: BTreeMap::new(),
+                elements: vec![
+                    KirElement {
+                        id: "Demo::Vehicle".to_string(),
+                        kind: "PartDefinition".to_string(),
+                        layer: 0,
+                        properties: BTreeMap::from([(
                             "declared_name".to_string(),
-                            Value::String("Real".to_string()),
-                        ),
-                        ("is_library_element".to_string(), Value::Bool(true)),
-                        (
-                            "pilot_library_group".to_string(),
-                            Value::String("Kernel Libraries".to_string()),
-                        ),
-                    ]),
-                },
-                KirElement {
-                    id: "KerML::Root::Element".to_string(),
-                    kind: "Metaclass".to_string(),
-                    layer: 1,
-                    properties: BTreeMap::from([
-                        (
-                            "declared_name".to_string(),
-                            Value::String("Element".to_string()),
-                        ),
-                        (
-                            "metamodel_layer".to_string(),
-                            Value::String("kernel".to_string()),
-                        ),
-                    ]),
-                },
-            ],
-        })
+                            Value::String("Vehicle".to_string()),
+                        )]),
+                    },
+                    KirElement {
+                        id: "ScalarValues::Real".to_string(),
+                        kind: "DataType".to_string(),
+                        layer: 1,
+                        properties: BTreeMap::from([
+                            (
+                                "declared_name".to_string(),
+                                Value::String("Real".to_string()),
+                            ),
+                            ("is_library_element".to_string(), Value::Bool(true)),
+                            (
+                                "pilot_library_group".to_string(),
+                                Value::String("Kernel Libraries".to_string()),
+                            ),
+                        ]),
+                    },
+                    KirElement {
+                        id: "KerML::Root::Element".to_string(),
+                        kind: "Metaclass".to_string(),
+                        layer: 1,
+                        properties: BTreeMap::from([
+                            (
+                                "declared_name".to_string(),
+                                Value::String("Element".to_string()),
+                            ),
+                            (
+                                "metamodel_layer".to_string(),
+                                Value::String("kernel".to_string()),
+                            ),
+                        ]),
+                    },
+                ],
+            }
+            .normalized_for_persistence(),
+        )
         .unwrap();
         let registry = CapabilityRegistry::with_foundation_builtins();
 
@@ -2349,35 +2368,38 @@ mod tests {
 
     #[test]
     fn model_inspection_query_scope_can_target_metamodel_only() {
-        let workspace = SemanticWorkspaceSnapshot::from_document(KirDocument {
-            metadata: BTreeMap::new(),
-            elements: vec![
-                KirElement {
-                    id: "Demo::ElementAdapter".to_string(),
-                    kind: "PartDefinition".to_string(),
-                    layer: 0,
-                    properties: BTreeMap::from([(
-                        "declared_name".to_string(),
-                        Value::String("ElementAdapter".to_string()),
-                    )]),
-                },
-                KirElement {
-                    id: "KerML::Root::Element".to_string(),
-                    kind: "Metaclass".to_string(),
-                    layer: 1,
-                    properties: BTreeMap::from([
-                        (
+        let workspace = SemanticWorkspaceSnapshot::from_document(
+            KirDocument {
+                metadata: BTreeMap::new(),
+                elements: vec![
+                    KirElement {
+                        id: "Demo::ElementAdapter".to_string(),
+                        kind: "PartDefinition".to_string(),
+                        layer: 0,
+                        properties: BTreeMap::from([(
                             "declared_name".to_string(),
-                            Value::String("Element".to_string()),
-                        ),
-                        (
-                            "metamodel_layer".to_string(),
-                            Value::String("kernel".to_string()),
-                        ),
-                    ]),
-                },
-            ],
-        })
+                            Value::String("ElementAdapter".to_string()),
+                        )]),
+                    },
+                    KirElement {
+                        id: "KerML::Root::Element".to_string(),
+                        kind: "Metaclass".to_string(),
+                        layer: 1,
+                        properties: BTreeMap::from([
+                            (
+                                "declared_name".to_string(),
+                                Value::String("Element".to_string()),
+                            ),
+                            (
+                                "metamodel_layer".to_string(),
+                                Value::String("kernel".to_string()),
+                            ),
+                        ]),
+                    },
+                ],
+            }
+            .normalized_for_persistence(),
+        )
         .unwrap();
         let registry = CapabilityRegistry::with_foundation_builtins();
 
@@ -2413,32 +2435,35 @@ mod tests {
 
     #[test]
     fn graph_impact_workspace_hotspots_ignore_library_elements() {
-        let workspace = SemanticWorkspaceSnapshot::from_document(KirDocument {
-            metadata: BTreeMap::new(),
-            elements: vec![
-                KirElement {
-                    id: "ScalarValues::Real".to_string(),
-                    kind: "DataType".to_string(),
-                    layer: 1,
-                    properties: BTreeMap::from([
-                        (
-                            "declared_name".to_string(),
-                            Value::String("Real".to_string()),
-                        ),
-                        ("is_library_element".to_string(), Value::Bool(true)),
-                        (
-                            "pilot_library_group".to_string(),
-                            Value::String("Kernel Libraries".to_string()),
-                        ),
-                    ]),
-                },
-                typed_usage("part.engine.power", "ScalarValues::Real"),
-                typed_usage("part.engine.torque", "ScalarValues::Real"),
-                typed_usage("part.engine.speed", "ScalarValues::Real"),
-                typed_usage("part.engine.temperature", "ScalarValues::Real"),
-                typed_usage("part.engine.efficiency", "ScalarValues::Real"),
-            ],
-        })
+        let workspace = SemanticWorkspaceSnapshot::from_document(
+            KirDocument {
+                metadata: BTreeMap::new(),
+                elements: vec![
+                    KirElement {
+                        id: "ScalarValues::Real".to_string(),
+                        kind: "DataType".to_string(),
+                        layer: 1,
+                        properties: BTreeMap::from([
+                            (
+                                "declared_name".to_string(),
+                                Value::String("Real".to_string()),
+                            ),
+                            ("is_library_element".to_string(), Value::Bool(true)),
+                            (
+                                "pilot_library_group".to_string(),
+                                Value::String("Kernel Libraries".to_string()),
+                            ),
+                        ]),
+                    },
+                    typed_usage("part.engine.power", "ScalarValues::Real"),
+                    typed_usage("part.engine.torque", "ScalarValues::Real"),
+                    typed_usage("part.engine.speed", "ScalarValues::Real"),
+                    typed_usage("part.engine.temperature", "ScalarValues::Real"),
+                    typed_usage("part.engine.efficiency", "ScalarValues::Real"),
+                ],
+            }
+            .normalized_for_persistence(),
+        )
         .unwrap();
         let registry = CapabilityRegistry::with_foundation_builtins();
 
@@ -2473,30 +2498,33 @@ mod tests {
 
     #[test]
     fn graph_impact_workspace_scope_can_target_stdlib_elements() {
-        let workspace = SemanticWorkspaceSnapshot::from_document(KirDocument {
-            metadata: BTreeMap::new(),
-            elements: vec![
-                KirElement {
-                    id: "ScalarValues::Real".to_string(),
-                    kind: "DataType".to_string(),
-                    layer: 1,
-                    properties: BTreeMap::from([
-                        (
-                            "declared_name".to_string(),
-                            Value::String("Real".to_string()),
-                        ),
-                        ("is_library_element".to_string(), Value::Bool(true)),
-                        (
-                            "pilot_library_group".to_string(),
-                            Value::String("Kernel Libraries".to_string()),
-                        ),
-                    ]),
-                },
-                typed_usage("part.engine.power", "ScalarValues::Real"),
-                typed_usage("part.engine.torque", "ScalarValues::Real"),
-                typed_usage("part.engine.speed", "ScalarValues::Real"),
-            ],
-        })
+        let workspace = SemanticWorkspaceSnapshot::from_document(
+            KirDocument {
+                metadata: BTreeMap::new(),
+                elements: vec![
+                    KirElement {
+                        id: "ScalarValues::Real".to_string(),
+                        kind: "DataType".to_string(),
+                        layer: 1,
+                        properties: BTreeMap::from([
+                            (
+                                "declared_name".to_string(),
+                                Value::String("Real".to_string()),
+                            ),
+                            ("is_library_element".to_string(), Value::Bool(true)),
+                            (
+                                "pilot_library_group".to_string(),
+                                Value::String("Kernel Libraries".to_string()),
+                            ),
+                        ]),
+                    },
+                    typed_usage("part.engine.power", "ScalarValues::Real"),
+                    typed_usage("part.engine.torque", "ScalarValues::Real"),
+                    typed_usage("part.engine.speed", "ScalarValues::Real"),
+                ],
+            }
+            .normalized_for_persistence(),
+        )
         .unwrap();
         let registry = CapabilityRegistry::with_foundation_builtins();
 
@@ -2704,6 +2732,7 @@ mod tests {
                 element_id: "element.test".to_string(),
                 qualified_name: None,
                 label: Some("Test Element".to_string()),
+                semantic_anchor: None,
             },
             claim: "test insight".to_string(),
             polarity,

--- a/crates/mercurio-foundation/src/cognitive.rs
+++ b/crates/mercurio-foundation/src/cognitive.rs
@@ -879,6 +879,7 @@ fn semantic_element_ref(element: &Element) -> SemanticElementRef {
                     .find(|part| !part.is_empty())
                     .map(ToOwned::to_owned)
             }),
+        semantic_anchor: None,
     }
 }
 
@@ -1028,6 +1029,7 @@ mod tests {
             element_id: "Vehicle.engine".to_string(),
             qualified_name: Some("Vehicle.engine".to_string()),
             label: Some("engine".to_string()),
+            semantic_anchor: None,
         }]);
         let context = CognitiveContext::from_document(test_document(), focus).unwrap();
 

--- a/crates/mercurio-foundation/src/dsl/mod.rs
+++ b/crates/mercurio-foundation/src/dsl/mod.rs
@@ -717,6 +717,7 @@ fn insight_from_result(
             element_id: "workspace".to_string(),
             qualified_name: None,
             label: Some("Workspace".to_string()),
+            semantic_anchor: None,
         }),
         claim: claim.to_string(),
         polarity,
@@ -782,11 +783,13 @@ fn semantic_element_ref(graph: &Graph, element_id: &str) -> SemanticElementRef {
                 .or_else(|| element.properties.get("name"))
                 .and_then(Value::as_str)
                 .map(str::to_string),
+            semantic_anchor: None,
         })
         .unwrap_or_else(|| SemanticElementRef {
             element_id: element_id.to_string(),
             qualified_name: None,
             label: None,
+            semantic_anchor: None,
         })
 }
 

--- a/crates/mercurio-foundation/src/semantic_validation.rs
+++ b/crates/mercurio-foundation/src/semantic_validation.rs
@@ -30,7 +30,7 @@ impl SemanticValidationMode {
 
 impl Default for SemanticValidationMode {
     fn default() -> Self {
-        Self::Warn
+        Self::Error
     }
 }
 
@@ -64,7 +64,7 @@ impl Default for SemanticValidationPolicy {
     fn default() -> Self {
         Self {
             version: SEMANTIC_VALIDATION_POLICY_VERSION,
-            mode: SemanticValidationMode::Warn,
+            mode: SemanticValidationMode::Error,
         }
     }
 }
@@ -227,7 +227,7 @@ mod tests {
     use crate::ir::{KIR_SCHEMA_VERSION, KirElement};
 
     #[test]
-    fn metamodel_validation_reports_warnings_against_document_elements() {
+    fn metamodel_validation_reports_errors_against_document_elements() {
         let document = KirDocument {
             metadata: BTreeMap::from([(
                 "kir_schema_version".to_string(),
@@ -245,7 +245,7 @@ mod tests {
         let report =
             validate_kir_semantics_with_context(&document, Some(&library_context)).unwrap();
 
-        assert_eq!(report.warning_count(), 1);
+        assert_eq!(report.error_count(), 1);
         assert_eq!(
             report.diagnostics[0].code,
             "kir.metamodel.endpoints.incomplete"
@@ -257,7 +257,7 @@ mod tests {
     }
 
     #[test]
-    fn error_policy_promotes_semantic_diagnostics_to_errors() {
+    fn warn_policy_reports_semantic_diagnostics_as_warnings() {
         let document = KirDocument {
             metadata: BTreeMap::from([(
                 "kir_schema_version".to_string(),
@@ -276,15 +276,15 @@ mod tests {
             &document,
             Some(&library_context),
             SemanticValidationPolicy {
-                mode: SemanticValidationMode::Error,
+                mode: SemanticValidationMode::Warn,
                 ..SemanticValidationPolicy::default()
             },
         )
         .unwrap();
 
-        assert_eq!(report.warning_count(), 0);
-        assert_eq!(report.error_count(), 1);
-        assert!(report.has_errors());
+        assert_eq!(report.warning_count(), 1);
+        assert_eq!(report.error_count(), 0);
+        assert!(!report.has_errors());
     }
 
     #[test]

--- a/crates/mercurio-foundation/src/workspace_cache.rs
+++ b/crates/mercurio-foundation/src/workspace_cache.rs
@@ -1385,8 +1385,8 @@ mod tests {
 
     use super::{
         PersistentCacheStatus, PersistentWorkspaceCache, RUNTIME_CACHE_FILE_NAME,
-        RUNTIME_CACHE_MANIFEST_FILE_NAME, RuntimeCachePolicy, SemanticValidationPolicy,
-        WorkspaceCompileCacheManifest, source_file_fingerprints,
+        RUNTIME_CACHE_MANIFEST_FILE_NAME, RuntimeCachePolicy, SemanticValidationMode,
+        SemanticValidationPolicy, WorkspaceCompileCacheManifest, source_file_fingerprints,
     };
     use crate::ir::{KIR_SCHEMA_VERSION, KirDocument, KirElement, KirError};
     use crate::runtime::Runtime;
@@ -1596,7 +1596,11 @@ mod tests {
     #[test]
     fn persistent_compile_cache_reports_semantic_validation_on_miss_and_hit() {
         let root = temp_dir("persistent_validation_report");
-        let cache = PersistentWorkspaceCache::for_workspace_root(&root);
+        let cache = PersistentWorkspaceCache::for_workspace_root(&root)
+            .with_semantic_validation_policy(SemanticValidationPolicy {
+                mode: SemanticValidationMode::Warn,
+                ..SemanticValidationPolicy::default()
+            });
         let library_context = validation_library_context();
         let sources = vec![SourceDocument::new("demo.model", "transition start")];
 
@@ -1624,6 +1628,31 @@ mod tests {
         assert_eq!(
             hit.validation_report.diagnostics[0].code,
             "kir.metamodel.endpoints.incomplete"
+        );
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn persistent_compile_cache_rejects_semantic_validation_errors_by_default() {
+        let root = temp_dir("persistent_validation_error");
+        let cache = PersistentWorkspaceCache::for_workspace_root(&root);
+        let library_context = validation_library_context();
+        let sources = vec![SourceDocument::new("demo.model", "transition start")];
+
+        let error = cache
+            .compile_source_documents_with(
+                sources,
+                &library_context,
+                None,
+                compile_transition_warning_document,
+            )
+            .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("semantic validation failed with 1 error diagnostics")
         );
 
         std::fs::remove_dir_all(root).unwrap();

--- a/crates/mercurio-kir/src/lib.rs
+++ b/crates/mercurio-kir/src/lib.rs
@@ -380,6 +380,7 @@ const CORE_FIELD_SPECS: &[(&str, KirFieldKind)] = &[
     ("operator_expression", KirFieldKind::Scalar),
     ("trigger", KirFieldKind::Scalar),
     ("trigger_kind", KirFieldKind::Scalar),
+    ("is_initial", KirFieldKind::Scalar),
     ("source_is_initial", KirFieldKind::Scalar),
     ("effect", KirFieldKind::Scalar),
     ("text", KirFieldKind::Scalar),
@@ -575,12 +576,6 @@ impl KirDocument {
         Ok(document)
     }
 
-    pub fn from_str_lenient(input: &str) -> Result<Self, KirError> {
-        let document: Self = serde_json::from_str(input)?;
-        document.validate()?;
-        Ok(document.normalized_for_persistence())
-    }
-
     pub fn from_slice(bytes: &[u8]) -> Result<Self, KirError> {
         let input = std::str::from_utf8(bytes)
             .map_err(|_| KirError::Model("KIR bytes are not valid UTF-8".to_string()))?;
@@ -590,11 +585,6 @@ impl KirDocument {
     pub fn from_path(path: &Path) -> Result<Self, KirError> {
         let input = std::fs::read_to_string(path)?;
         Self::from_str(&input)
-    }
-
-    pub fn from_path_lenient(path: &Path) -> Result<Self, KirError> {
-        let input = std::fs::read_to_string(path)?;
-        Self::from_str_lenient(&input)
     }
 
     pub fn validate(&self) -> Result<(), KirError> {


### PR DESCRIPTION
## Summary
- make semantic validation default to error mode
- require persisted strict KIR for capability snapshots and remove lenient persisted readers
- carry optional semantic anchors on semantic element refs
- add enforcement tests for default validation failure and warning-mode opt-in

## Verification
- cargo check -q
- cargo test -q