### PR TITLE
release: prepare Foundation crates 0.85.0

### DIFF
--- a/.github/workflows/crates-release.yml
+++ b/.github/workflows/crates-release.yml
@@ -1,0 +1,103 @@
+name: Crates release
+
+on:
+  push:
+    tags:
+      - "foundation-v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: crates-foundation-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  qualify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Validate release identity
+        shell: bash
+        run: |
+          version="$(awk '/^\[workspace.package\]/{in_package=1; next} in_package && /^version = /{gsub(/"/, "", $3); print $3; exit}' Cargo.toml)"
+          test -n "${version}"
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            test "${GITHUB_REF_NAME}" = "foundation-v${version}"
+          fi
+      - name: Test workspace
+        run: cargo test --workspace --locked
+      - name: Assemble crates.io packages
+        run: cargo package --workspace --no-verify --locked
+
+  publish:
+    if: github.ref_type == 'tag'
+    needs: qualify
+    runs-on: ubuntu-latest
+    environment: crates-io
+    env:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Publish packages in dependency order
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(awk '/^\[workspace.package\]/{in_package=1; next} in_package && /^version = /{gsub(/"/, "", $3); print $3; exit}' Cargo.toml)"
+          packages=(
+            mercurio-kir
+            mercurio-simulation-core
+            mercurio-language-contracts
+            mercurio-model
+            mercurio-authoring
+            mercurio-runtime
+            mercurio-semantic-services
+            mercurio-views
+            mercurio-workspace
+            mercurio-analysis
+            mercurio-codegen
+            mercurio-session
+            mercurio-query-dsl
+            mercurio-core
+            mercurio-foundation
+          )
+
+          published() {
+            curl --fail --silent --show-error \
+              --header "User-Agent: mercurio-foundation-release/${version}" \
+              "https://crates.io/api/v1/crates/$1" |
+              jq --exit-status --arg version "${version}" \
+                '.versions | any(.num == $version)' >/dev/null
+          }
+
+          publish_one() {
+            local package="$1"
+            if published "${package}"; then
+              echo "${package} ${version} is already published"
+              return
+            fi
+
+            for attempt in {1..12}; do
+              if cargo publish --locked --package "${package}"; then
+                return
+              fi
+              if published "${package}"; then
+                return
+              fi
+              if [[ "${attempt}" -eq 12 ]]; then
+                echo "failed to publish ${package} ${version}" >&2
+                return 1
+              fi
+              sleep 10
+            done
+          }
+
+          for package in "${packages[@]}"; do
+            publish_one "${package}"
+          done

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mercurio-analysis"
-version = "0.1.0"
+version = "0.85.0"
 dependencies = [
  "mercurio-kir",
  "mercurio-model",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "mercurio-authoring"
-version = "0.1.0"
+version = "0.85.0"
 dependencies = [
  "mercurio-kir",
  "mercurio-language-contracts",
@@ -192,7 +192,7 @@ dependencies = [
 
 [[package]]
 name = "mercurio-codegen"
-version = "0.1.0"
+version = "0.85.0"
 dependencies = [
  "mercurio-kir",
  "mercurio-language-contracts",
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "mercurio-core"
-version = "0.1.0"
+version = "0.85.0"
 dependencies = [
  "mercurio-analysis",
  "mercurio-authoring",
@@ -224,8 +224,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mercurio-foundation"
+version = "0.85.0"
+dependencies = [
+ "mercurio-core",
+]
+
+[[package]]
 name = "mercurio-kir"
-version = "0.1.0"
+version = "0.85.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -233,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "mercurio-language-contracts"
-version = "0.1.0"
+version = "0.85.0"
 dependencies = [
  "mercurio-kir",
  "serde",
@@ -242,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "mercurio-model"
-version = "0.1.0"
+version = "0.85.0"
 dependencies = [
  "mercurio-kir",
  "mercurio-language-contracts",
@@ -252,7 +259,7 @@ dependencies = [
 
 [[package]]
 name = "mercurio-query-dsl"
-version = "0.1.0"
+version = "0.85.0"
 dependencies = [
  "mercurio-analysis",
  "mercurio-kir",
@@ -268,7 +275,7 @@ dependencies = [
 
 [[package]]
 name = "mercurio-runtime"
-version = "0.1.0"
+version = "0.85.0"
 dependencies = [
  "mercurio-kir",
  "mercurio-model",
@@ -278,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "mercurio-semantic-services"
-version = "0.1.0"
+version = "0.85.0"
 dependencies = [
  "mercurio-authoring",
  "mercurio-kir",
@@ -290,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "mercurio-session"
-version = "0.1.0"
+version = "0.85.0"
 dependencies = [
  "mercurio-analysis",
  "mercurio-authoring",
@@ -303,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "mercurio-simulation-core"
-version = "0.1.0"
+version = "0.85.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -311,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "mercurio-views"
-version = "0.1.0"
+version = "0.85.0"
 dependencies = [
  "mercurio-kir",
  "mercurio-model",
@@ -322,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "mercurio-workspace"
-version = "0.1.0"
+version = "0.85.0"
 dependencies = [
  "mercurio-authoring",
  "mercurio-kir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,14 @@ members = [
     "crates/mercurio-codegen",
     "crates/mercurio-session",
     "crates/mercurio-core",
+    "crates/mercurio-foundation",
     "crates/mercurio-simulation-core",
     "crates/mercurio-views",
 ]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.85.0"
 edition = "2024"
 license = "MIT"
 description = "KerML-aligned semantic modeling substrate and KIR runtime for Mercurio."

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ evolve without turning the facade into a catch-all crate.
 | `mercurio-session` | Session overlays, forks, host-authorized commits, and transaction reports. |
 | `mercurio-simulation-core` | Source-neutral deterministic simulation primitives over KIR-projected behavior facts. |
 | `mercurio-views` | View DTOs, element/model views, diagrams, tables, and deterministic view rendering helpers. |
-| `mercurio-core` | Compatibility facade crate. Its Cargo package is `mercurio-core`, and its library target remains `mercurio_core` for existing consumers. |
+| `mercurio-core` | Compatibility facade retained for existing consumers and internal integration. |
+| `mercurio-foundation` | Primary public facade and recommended crates.io dependency for new consumers. |
 
 See [Crates](docs/crates.md).
 
@@ -75,7 +76,7 @@ cargo run --manifest-path ..\mercurio-sysml\Cargo.toml -p mercurio-tools --bin c
 ```rust
 use std::collections::BTreeMap;
 
-use mercurio_core::{Graph, KIR_SCHEMA_VERSION, KirDocument, KirElement};
+use mercurio_foundation::{Graph, KIR_SCHEMA_VERSION, KirDocument, KirElement};
 use serde_json::json;
 
 let document = KirDocument {
@@ -113,3 +114,11 @@ cargo test --no-run
 ```
 
 Foundation tests use language-neutral KIR fixtures and a small test-only toy language service for registry, cache, graph, and runtime coverage.
+
+## Release
+
+Mercurio Foundation is one coordinated release unit. The public entry point and
+its implementation packages use the same version and are published together in
+dependency order.
+
+See [Releasing Mercurio Foundation](RELEASING.md).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,73 @@
+# Releasing Mercurio Foundation
+
+Mercurio Foundation is released as one product with `mercurio-foundation` as
+its public crates.io entry point. Its implementation crates are published
+because Cargo must be able to resolve every transitive dependency from the
+registry, but they are not separate product release trains.
+
+All publishable workspace packages use the version in `[workspace.package]`.
+Internal dependencies must retain both a local `path` and the matching
+registry `version`.
+
+## Qualification
+
+From this repository:
+
+```powershell
+cargo test --workspace --locked
+cargo doc --workspace --no-deps --locked
+cargo package --workspace --no-verify --locked
+```
+
+From the sibling `mercurio-sysml` repository:
+
+```powershell
+cargo run -p mercurio-tools --bin check_repo_boundaries -- --manifest ..\mercurio-foundation\repo-boundaries.json --strict
+```
+
+`cargo package --no-verify` validates package assembly before the internal
+versions exist in crates.io. The release workflow performs the registry-backed
+verification while publishing each package.
+
+## First Release
+
+Crate names are allocated by the first successful publish. Before pushing the
+first tag:
+
+1. Create a crates.io API token with permission to publish new crates.
+2. Add it to the `mercurio-foundation` GitHub repository as the
+   `CARGO_REGISTRY_TOKEN` Actions secret.
+3. Protect the optional `crates-io` GitHub environment if release approval is
+   desired.
+4. Merge the qualified release commit to `main`.
+5. Create and push `foundation-v<version>`, for example
+   `foundation-v0.85.0`.
+
+The workflow is resumable. It skips any package version already present on
+crates.io and retries dependents while the registry index catches up.
+
+After the first release, configure crates.io Trusted Publishing for this GitHub
+repository and replace the long-lived token step with the crates.io OIDC action.
+
+## Publish Order
+
+The workflow publishes:
+
+1. `mercurio-kir`
+2. `mercurio-simulation-core`
+3. `mercurio-language-contracts`
+4. `mercurio-model`
+5. `mercurio-authoring`
+6. `mercurio-runtime`
+7. `mercurio-semantic-services`
+8. `mercurio-views`
+9. `mercurio-workspace`
+10. `mercurio-analysis`
+11. `mercurio-codegen`
+12. `mercurio-session`
+13. `mercurio-query-dsl`
+14. `mercurio-core`
+15. `mercurio-foundation`
+
+Do not publish Foundation and SysML concurrently. A SysML release starts only
+after its required Foundation version is visible on crates.io.

--- a/crates/mercurio-analysis/Cargo.toml
+++ b/crates/mercurio-analysis/Cargo.toml
@@ -9,10 +9,10 @@ readme.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-mercurio-kir = { path = "../mercurio-kir", version = "0.1.0" }
-mercurio-model = { path = "../mercurio-model", version = "0.1.0" }
-mercurio-runtime = { path = "../mercurio-runtime", version = "0.1.0" }
-mercurio-semantic-services = { path = "../mercurio-semantic-services", version = "0.1.0" }
-mercurio-workspace = { path = "../mercurio-workspace", version = "0.1.0" }
+mercurio-kir = { path = "../mercurio-kir", version = "0.85.0" }
+mercurio-model = { path = "../mercurio-model", version = "0.85.0" }
+mercurio-runtime = { path = "../mercurio-runtime", version = "0.85.0" }
+mercurio-semantic-services = { path = "../mercurio-semantic-services", version = "0.85.0" }
+mercurio-workspace = { path = "../mercurio-workspace", version = "0.85.0" }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/mercurio-authoring/Cargo.toml
+++ b/crates/mercurio-authoring/Cargo.toml
@@ -9,9 +9,9 @@ readme.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-mercurio-kir = { path = "../mercurio-kir", version = "0.1.0" }
-mercurio-language-contracts = { path = "../mercurio-language-contracts", version = "0.1.0" }
-mercurio-model = { path = "../mercurio-model", version = "0.1.0" }
+mercurio-kir = { path = "../mercurio-kir", version = "0.85.0" }
+mercurio-language-contracts = { path = "../mercurio-language-contracts", version = "0.85.0" }
+mercurio-model = { path = "../mercurio-model", version = "0.85.0" }
 serde.workspace = true
 serde_json.workspace = true
 

--- a/crates/mercurio-codegen/Cargo.toml
+++ b/crates/mercurio-codegen/Cargo.toml
@@ -9,9 +9,9 @@ readme.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-mercurio-kir = { path = "../mercurio-kir", version = "0.1.0" }
-mercurio-language-contracts = { path = "../mercurio-language-contracts", version = "0.1.0" }
-mercurio-model = { path = "../mercurio-model", version = "0.1.0" }
-mercurio-workspace = { path = "../mercurio-workspace", version = "0.1.0" }
+mercurio-kir = { path = "../mercurio-kir", version = "0.85.0" }
+mercurio-language-contracts = { path = "../mercurio-language-contracts", version = "0.85.0" }
+mercurio-model = { path = "../mercurio-model", version = "0.85.0" }
+mercurio-workspace = { path = "../mercurio-workspace", version = "0.85.0" }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/mercurio-core/Cargo.toml
+++ b/crates/mercurio-core/Cargo.toml
@@ -12,17 +12,17 @@ rust-version.workspace = true
 name = "mercurio_core"
 
 [dependencies]
-mercurio-kir = { path = "../mercurio-kir", version = "0.1.0" }
-mercurio-authoring = { path = "../mercurio-authoring", version = "0.1.0" }
-mercurio-analysis = { path = "../mercurio-analysis", version = "0.1.0" }
-mercurio-codegen = { path = "../mercurio-codegen", version = "0.1.0" }
-mercurio-language-contracts = { path = "../mercurio-language-contracts", version = "0.1.0" }
-mercurio-model = { path = "../mercurio-model", version = "0.1.0" }
-mercurio-query-dsl = { path = "../mercurio-query-dsl", version = "0.1.0" }
-mercurio-runtime = { path = "../mercurio-runtime", version = "0.1.0" }
-mercurio-semantic-services = { path = "../mercurio-semantic-services", version = "0.1.0" }
-mercurio-session = { path = "../mercurio-session", version = "0.1.0" }
-mercurio-workspace = { path = "../mercurio-workspace", version = "0.1.0" }
+mercurio-kir = { path = "../mercurio-kir", version = "0.85.0" }
+mercurio-authoring = { path = "../mercurio-authoring", version = "0.85.0" }
+mercurio-analysis = { path = "../mercurio-analysis", version = "0.85.0" }
+mercurio-codegen = { path = "../mercurio-codegen", version = "0.85.0" }
+mercurio-language-contracts = { path = "../mercurio-language-contracts", version = "0.85.0" }
+mercurio-model = { path = "../mercurio-model", version = "0.85.0" }
+mercurio-query-dsl = { path = "../mercurio-query-dsl", version = "0.85.0" }
+mercurio-runtime = { path = "../mercurio-runtime", version = "0.85.0" }
+mercurio-semantic-services = { path = "../mercurio-semantic-services", version = "0.85.0" }
+mercurio-session = { path = "../mercurio-session", version = "0.85.0" }
+mercurio-workspace = { path = "../mercurio-workspace", version = "0.85.0" }
 serde.workspace = true
 serde_json.workspace = true
 rhai.workspace = true

--- a/crates/mercurio-foundation/Cargo.toml
+++ b/crates/mercurio-foundation/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "mercurio-foundation"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Public Rust facade for Mercurio's language-neutral semantic modeling foundation."
+repository.workspace = true
+readme.workspace = true
+rust-version.workspace = true
+keywords = ["modeling", "semantic", "sysml", "simulation"]
+categories = ["data-structures", "development-tools"]
+
+[dependencies]
+mercurio-core = { path = "../mercurio-core", version = "0.85.0" }

--- a/crates/mercurio-foundation/src/lib.rs
+++ b/crates/mercurio-foundation/src/lib.rs
@@ -1,0 +1,19 @@
+//! Public facade for the language-neutral Mercurio semantic platform.
+//!
+//! Applications should prefer this crate over depending directly on Mercurio's
+//! implementation crates. Language integrations, including SysML, build on the
+//! contracts and runtime exposed here.
+
+pub use mercurio_core::*;
+
+#[cfg(test)]
+mod tests {
+    use super::{Graph, Runtime};
+
+    #[test]
+    fn facade_exposes_model_and_runtime_types() {
+        fn accepts_public_types(_: Option<Graph>, _: Option<Runtime>) {}
+
+        accepts_public_types(None, None);
+    }
+}

--- a/crates/mercurio-language-contracts/Cargo.toml
+++ b/crates/mercurio-language-contracts/Cargo.toml
@@ -9,6 +9,6 @@ readme.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-mercurio-kir = { path = "../mercurio-kir", version = "0.1.0" }
+mercurio-kir = { path = "../mercurio-kir", version = "0.85.0" }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/mercurio-model/Cargo.toml
+++ b/crates/mercurio-model/Cargo.toml
@@ -9,7 +9,7 @@ readme.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-mercurio-kir = { path = "../mercurio-kir", version = "0.1.0" }
-mercurio-language-contracts = { path = "../mercurio-language-contracts", version = "0.1.0" }
+mercurio-kir = { path = "../mercurio-kir", version = "0.85.0" }
+mercurio-language-contracts = { path = "../mercurio-language-contracts", version = "0.85.0" }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/mercurio-query-dsl/Cargo.toml
+++ b/crates/mercurio-query-dsl/Cargo.toml
@@ -9,13 +9,13 @@ readme.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-mercurio-analysis = { path = "../mercurio-analysis", version = "0.1.0" }
-mercurio-kir = { path = "../mercurio-kir", version = "0.1.0" }
-mercurio-model = { path = "../mercurio-model", version = "0.1.0" }
-mercurio-runtime = { path = "../mercurio-runtime", version = "0.1.0" }
-mercurio-semantic-services = { path = "../mercurio-semantic-services", version = "0.1.0" }
-mercurio-session = { path = "../mercurio-session", version = "0.1.0" }
-mercurio-workspace = { path = "../mercurio-workspace", version = "0.1.0" }
+mercurio-analysis = { path = "../mercurio-analysis", version = "0.85.0" }
+mercurio-kir = { path = "../mercurio-kir", version = "0.85.0" }
+mercurio-model = { path = "../mercurio-model", version = "0.85.0" }
+mercurio-runtime = { path = "../mercurio-runtime", version = "0.85.0" }
+mercurio-semantic-services = { path = "../mercurio-semantic-services", version = "0.85.0" }
+mercurio-session = { path = "../mercurio-session", version = "0.85.0" }
+mercurio-workspace = { path = "../mercurio-workspace", version = "0.85.0" }
 rhai.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/mercurio-runtime/Cargo.toml
+++ b/crates/mercurio-runtime/Cargo.toml
@@ -9,7 +9,7 @@ readme.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-mercurio-kir = { path = "../mercurio-kir", version = "0.1.0" }
-mercurio-model = { path = "../mercurio-model", version = "0.1.0" }
+mercurio-kir = { path = "../mercurio-kir", version = "0.85.0" }
+mercurio-model = { path = "../mercurio-model", version = "0.85.0" }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/mercurio-semantic-services/Cargo.toml
+++ b/crates/mercurio-semantic-services/Cargo.toml
@@ -9,12 +9,12 @@ readme.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-mercurio-authoring = { path = "../mercurio-authoring", version = "0.1.0" }
-mercurio-kir = { path = "../mercurio-kir", version = "0.1.0" }
-mercurio-model = { path = "../mercurio-model", version = "0.1.0" }
-mercurio-runtime = { path = "../mercurio-runtime", version = "0.1.0" }
+mercurio-authoring = { path = "../mercurio-authoring", version = "0.85.0" }
+mercurio-kir = { path = "../mercurio-kir", version = "0.85.0" }
+mercurio-model = { path = "../mercurio-model", version = "0.85.0" }
+mercurio-runtime = { path = "../mercurio-runtime", version = "0.85.0" }
 serde.workspace = true
 serde_json.workspace = true
 
 [dev-dependencies]
-mercurio-authoring = { path = "../mercurio-authoring", version = "0.1.0", features = ["toy-parser"] }
+mercurio-authoring = { path = "../mercurio-authoring", version = "0.85.0", features = ["toy-parser"] }

--- a/crates/mercurio-session/Cargo.toml
+++ b/crates/mercurio-session/Cargo.toml
@@ -9,13 +9,13 @@ readme.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-mercurio-analysis = { path = "../mercurio-analysis", version = "0.1.0" }
-mercurio-authoring = { path = "../mercurio-authoring", version = "0.1.0" }
-mercurio-kir = { path = "../mercurio-kir", version = "0.1.0" }
-mercurio-semantic-services = { path = "../mercurio-semantic-services", version = "0.1.0" }
-mercurio-workspace = { path = "../mercurio-workspace", version = "0.1.0" }
+mercurio-analysis = { path = "../mercurio-analysis", version = "0.85.0" }
+mercurio-authoring = { path = "../mercurio-authoring", version = "0.85.0" }
+mercurio-kir = { path = "../mercurio-kir", version = "0.85.0" }
+mercurio-semantic-services = { path = "../mercurio-semantic-services", version = "0.85.0" }
+mercurio-workspace = { path = "../mercurio-workspace", version = "0.85.0" }
 serde.workspace = true
 serde_json.workspace = true
 
 [dev-dependencies]
-mercurio-authoring = { path = "../mercurio-authoring", version = "0.1.0", features = ["toy-parser"] }
+mercurio-authoring = { path = "../mercurio-authoring", version = "0.85.0", features = ["toy-parser"] }

--- a/crates/mercurio-views/Cargo.toml
+++ b/crates/mercurio-views/Cargo.toml
@@ -9,8 +9,8 @@ readme.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-mercurio-kir = { path = "../mercurio-kir", version = "0.1.0" }
-mercurio-model = { path = "../mercurio-model", version = "0.1.0" }
-mercurio-runtime = { path = "../mercurio-runtime", version = "0.1.0" }
+mercurio-kir = { path = "../mercurio-kir", version = "0.85.0" }
+mercurio-model = { path = "../mercurio-model", version = "0.85.0" }
+mercurio-runtime = { path = "../mercurio-runtime", version = "0.85.0" }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/mercurio-workspace/Cargo.toml
+++ b/crates/mercurio-workspace/Cargo.toml
@@ -9,12 +9,12 @@ readme.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-mercurio-authoring = { path = "../mercurio-authoring", version = "0.1.0" }
-mercurio-kir = { path = "../mercurio-kir", version = "0.1.0" }
-mercurio-language-contracts = { path = "../mercurio-language-contracts", version = "0.1.0" }
-mercurio-model = { path = "../mercurio-model", version = "0.1.0" }
-mercurio-runtime = { path = "../mercurio-runtime", version = "0.1.0" }
-mercurio-semantic-services = { path = "../mercurio-semantic-services", version = "0.1.0" }
+mercurio-authoring = { path = "../mercurio-authoring", version = "0.85.0" }
+mercurio-kir = { path = "../mercurio-kir", version = "0.85.0" }
+mercurio-language-contracts = { path = "../mercurio-language-contracts", version = "0.85.0" }
+mercurio-model = { path = "../mercurio-model", version = "0.85.0" }
+mercurio-runtime = { path = "../mercurio-runtime", version = "0.85.0" }
+mercurio-semantic-services = { path = "../mercurio-semantic-services", version = "0.85.0" }
 serde.workspace = true
 serde_json.workspace = true
 zip.workspace = true

--- a/repo-boundaries.json
+++ b/repo-boundaries.json
@@ -10,6 +10,7 @@
     "mercurio-analysis",
     "mercurio-authoring",
     "mercurio-codegen",
+    "mercurio-foundation",
     "mercurio-query-dsl",
     "mercurio-semantic-services",
     "mercurio-session",
@@ -132,6 +133,22 @@
       "mercurio-wasm"
     ],
     "mercurio-codegen": [
+      "mercurio-adapter",
+      "mercurio-ai",
+      "mercurio-console-api",
+      "mercurio-capability-api",
+      "mercurio-plugin-api",
+      "mercurio-plugin-host",
+      "mercurio-reference-capabilities",
+      "mercurio-product",
+      "mercurio-python",
+      "mercurio-reasoner-api",
+      "mercurio-reasoner-host",
+      "mercurio-reasoning-services",
+      "mercurio-views",
+      "mercurio-wasm"
+    ],
+    "mercurio-foundation": [
       "mercurio-adapter",
       "mercurio-ai",
       "mercurio-console-api",


### PR DESCRIPTION
## Summary
- add the mercurio-foundation public facade crate
- align the Foundation workspace and internal dependencies at 0.85.0
- add ordered, resumable crates.io release automation and release documentation
- extend repository-boundary enforcement to the facade

## Verification
- cargo test --workspace --locked
- strict repository boundary check
- offline packaging of all 15 packages
- live cargo publish --dry-run for the first package

## Release order
Merge and release this repository before mercurio-sysml.